### PR TITLE
chore: post-merge cleanup — dead code + .item() sync count

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -78,25 +78,6 @@ def run_stage_a(args: argparse.Namespace) -> Dict[str, object]:
     }
 
 
-def _load_stage_b_state_dict(checkpoint_path: Path, device) -> Dict[str, object]:
-    import torch
-
-    payload = torch.load(str(checkpoint_path), map_location=device)
-    state_dict = payload.get("model_state_dict", payload) if isinstance(payload, dict) else payload
-    if not isinstance(state_dict, dict):
-        raise RuntimeError(f"Unsupported checkpoint format: {checkpoint_path}")
-
-    normalized: Dict[str, object] = {}
-    for name, tensor in state_dict.items():
-        key = str(name)
-        for prefix in ("base_model.model.", "model."):
-            if key.startswith(prefix):
-                key = key[len(prefix) :]
-                break
-        normalized[key] = tensor
-    return normalized
-
-
 def _load_stage_b_crop_tensor(
     crop_path: Path,
     *,

--- a/src/train/train.py
+++ b/src/train/train.py
@@ -1677,10 +1677,10 @@ def run_execute_mode(
                     loss.backward()
 
                 if not is_accum_step:
-                    # Cache a lightweight scalar for the per-step JSONL record
-                    # (single detach; no .item() sync on non-accumulation steps).
-                    _loss_scalar_cache = loss.detach().float()
-                    losses.append(float(_loss_scalar_cache.item()) * accum_steps)
+                    # Single CPU sync per micro-batch; cache the python float so any
+                    # downstream consumer reads from CPU memory rather than re-syncing.
+                    _loss_scalar_cache = loss.detach().item() * accum_steps
+                    losses.append(_loss_scalar_cache)
                     timer.micro_batch_done()
                     continue
 
@@ -1728,9 +1728,10 @@ def run_execute_mode(
                 with timer.gpu("optimizer"):
                     optimizer.step()
                     scheduler.step()
-                # Cache the loss scalar once to avoid multiple .item() syncs below.
-                _loss_scalar_cache = loss.detach().float()
-                losses.append(float(_loss_scalar_cache.item()) * accum_steps)
+                # Single CPU sync per optimizer step; the python float is reused
+                # below by the JSONL record without re-syncing.
+                _loss_scalar_cache = loss.detach().item() * accum_steps
+                losses.append(_loss_scalar_cache)
                 global_step += 1
 
                 lr_map = {group.get("group_name", f"group_{idx}"): group["lr"] for idx, group in enumerate(optimizer.param_groups)}
@@ -1820,8 +1821,9 @@ def run_execute_mode(
 
                 if step_writer is not None:
                     with timer.cpu("log_io"):
-                        # Use the cached float scalar — avoids extra .item() syncs.
-                        _loss_float = float(_loss_scalar_cache.item()) * accum_steps
+                        # _loss_scalar_cache is already a python float (synced once
+                        # per opt-step above); reusing it costs nothing.
+                        _loss_float = _loss_scalar_cache
                         record = {
                             "timestamp_utc": datetime.now(timezone.utc).isoformat(),
                             "global_step": global_step,


### PR DESCRIPTION
## Summary

Two minor cleanups flagged during the PR #9 / #11 review pass.

### 1. `src/cli.py`: drop the dead `_load_stage_b_state_dict`

PR #9 routed every loader call through `src.checkpoint_io.load_stage_b_checkpoint`, so the old helper has zero callers. Removed.

### 2. `src/train/train.py`: collapse `.detach().float()` + `.item()` to one `.item()` call

The old pattern stored a 0-dim tensor in `_loss_scalar_cache` and called `.item()` on it twice per optimizer step (once for `losses.append`, once for the JSONL record). Each `.item()` syncs CUDA→CPU. Replaced with a single `.item()` that produces a python float; the JSONL block reuses that float directly.

Per-optimizer-step sync count:
| | before | after |
|--|--|--|
| diag step | 4 | 3 |
| non-diag step | 2 | 1 |

Numerics unchanged. The change preserves the exact loss values written to the step log.

## Test plan

- [x] All 26 existing tests pass on a fresh `torch==2.11.0+cpu` venv (python 3.14): 9 checkpoint_io + prediction_lookup, 9 diag-cadence, 5 attention-backend, 3 channels_last (1 CUDA-skipped).
- [ ] Host smoke unchanged from the validation done on PR #9 + #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)