### PR TITLE
chore(deps): pin Pillow ~=12.1.0 (12.2.0 regresses cpu_encode ~2x)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,12 @@ music21
 lxml
 
 # Image processing
-Pillow
+# Pillow pinned to 12.1 — 12.2.0 introduces a ~2x cpu_encode regression
+# (image decode/resize) measured during the cu132 bench (Phase 3). The
+# regression is hidden by the DataLoader's worker prefetch on the default
+# --num-workers 4 path, but resurfaces with --num-workers 0 (Windows fallback).
+# See docs/perf/2026-04-27-cu132-rollout.md "follow-ups" section.
+Pillow~=12.1.0
 numpy
 scikit-image
 


### PR DESCRIPTION
## Summary

Pin Pillow to `~=12.1.0` to dodge a ~2x cpu_encode regression introduced in 12.2.0. Discovered during the cu132 bench (PR #14, Phase 3): cpu_encode jumped 48 ms → 106 ms (+121%) when going from cu128's Pillow 12.1.1 to cu132's Pillow 12.2.0. Same model, same data, same image-decode workload — the only changed variable was the toolchain venv, and Pillow 12.2.0 was the dominant version delta.

The regression is hidden by the DataLoader rewrite's worker prefetch on the default `--num-workers 4` path (workers run in parallel with GPU compute), but **resurfaces with `--num-workers 0`** — the Windows multiprocess fallback.

`~=12.1.0` (PEP 440 compatible-release) means `>=12.1.0, <12.2`; admits future 12.1.x patches and excludes 12.2.

## Test plan

- [x] `pip install -r requirements.txt` resolves Pillow 12.1.1 (the latest 12.1.x at time of writing).
- [ ] Re-run cu128 baseline bench with the pinned Pillow on a fresh venv to confirm cpu_encode returns to ~48 ms. **Not in this PR's scope** — the bench setup is in PR #14's `scripts/setup_venv_cu132.ps1`.
- [ ] Future follow-up: file a Pillow upstream issue if the 12.2 regression isn't already known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)