### PR TITLE
chore(scripts): synthetic_full_page regen launcher (WMI-detached, cairo PATH)

### DIFF
--- a/scripts/synthetic_regen_inner.ps1
+++ b/scripts/synthetic_regen_inner.ps1
@@ -1,0 +1,42 @@
+# Inner launcher for synthetic_full_page regeneration.
+# Generates ~20,000 synthetic full-page renders from openscore_lieder
+# sources in 4 verovio engraving styles. CPU-bound, several hours.
+#
+# Cairo dependency note (from data/README.md):
+# cairocffi (used by cairosvg, used by the synthetic generator) needs
+# libcairo-2.dll on PATH. The darktable installer bundles a working copy;
+# we prepend its bin directory so the generator can find it.
+#
+# Detached via the matching launch script using WMI Create.
+
+$ErrorActionPreference = "Continue"
+$repo = Join-Path $env:USERPROFILE "Clarity-OMR-Train-RADIO"
+$venv = Join-Path $repo "venv-cu132\Scripts\python.exe"
+$out  = Join-Path $repo "data\synthetic_full_page"
+$log  = Join-Path $repo "logs\synthetic_regen.log"
+$err  = Join-Path $repo "logs\synthetic_regen.err"
+$pidf = Join-Path $repo "logs\synthetic_regen.pid"
+
+# Prepend darktable's cairo to PATH for this process.
+$cairoBin = "C:\Program Files\darktable\bin"
+$env:PATH = $cairoBin + ";" + $env:PATH
+
+Set-Location $repo
+New-Item -ItemType Directory -Force -Path (Split-Path $log) | Out-Null
+$PID | Out-File -FilePath $pidf -Encoding ascii -NoNewline
+
+# Pre-flight: verify cairo loads in this process before kicking off the
+# multi-hour render. Catches a missing libcairo-2.dll early.
+& $venv -c "import cairocffi; print(f'cairocffi {cairocffi.__version__} OK; using cairo {cairocffi.cairo_version_string()}')" 2>&1 | Out-File -FilePath $log -Append -Encoding utf8
+
+$pyArgs = @(
+    "-m", "src.data.generate_synthetic",
+    "--mode", "render",
+    "--output-dir", $out,
+    "--workers", "8",
+    "--seed", "42"
+    # No --max-scores or --max-pages-per-score: render the full set.
+)
+
+& $venv @pyArgs *>>$log 2>>$err
+"=== EXIT_CODE=$LASTEXITCODE ===" | Out-File -FilePath $log -Append -Encoding utf8

--- a/scripts/synthetic_regen_launch.ps1
+++ b/scripts/synthetic_regen_launch.ps1
@@ -1,0 +1,13 @@
+# Detach the synthetic regen via WMI Create so it survives SSH close.
+$ErrorActionPreference = "Stop"
+$repo  = Join-Path $env:USERPROFILE "Clarity-OMR-Train-RADIO"
+$inner = Join-Path $repo "scripts\synthetic_regen_inner.ps1"
+$cmdLine = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File `"$inner`""
+$result = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{ CommandLine = $cmdLine }
+if ($result.ReturnValue -ne 0) {
+    Write-Error "Win32_Process Create failed (ReturnValue=$($result.ReturnValue))"
+    exit 1
+}
+Write-Host "DETACHED_PID=$($result.ProcessId)"
+Write-Host "LOG=$repo\logs\synthetic_regen.log"
+Write-Host "ERR=$repo\logs\synthetic_regen.err"


### PR DESCRIPTION
## Summary

Adds a WMI-detached launcher pair for regenerating `data/synthetic_full_page/`. Bakes in two operational gotchas:

1. **`libcairo-2.dll` PATH** — `cairocffi` (used by `cairosvg`, used by the synthetic generator) needs `libcairo-2.dll` on PATH on Windows. The darktable installer at `C:\Program Files\darktable\bin\` ships a working copy. The inner script prepends that to PATH before invoking python, and a tiny pre-flight `import cairocffi; print(cairo_version_string())` surfaces a missing-cairo failure before the multi-hour render commits.
2. **venv-cu132 target** — the cu132 venv has `verovio`/`cairosvg`/`cairocffi` installed (they got pulled in during the 2026-04-27 cu132 session). Running against `venv` would need those deps installed there too.

Replaces the now-incorrect recipe from `data/README.md` (which said `--num-pages 20000 --seed 42` but the script's actual CLI takes `--max-scores` / `--max-pages-per-score` / `--workers` / `--seed`).

## Test plan

- [x] Cairo smoke: `import cairocffi; cairocffi.cairo_version_string()` → `1.18.4` with the darktable PATH prefix.
- [x] Generator smoke (2 sources × 2 pages, 4 styles): 0 failures, 214 token entries written.
- [ ] Full regen (~20K pages, 4 hr CPU) — fired separately, output to `data/synthetic_full_page/`. Already detached; check `logs/synthetic_regen.log` for the `=== EXIT_CODE= ===` sentinel.

## Independent of PR #14 / #15 / #16

This is a small operational tooling change and doesn't touch any of the cu132 wheel / DataLoader / pillow-pin work in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)