### PR TITLE
feat(eval): two-pass inference+scoring for canonical demo pieces

### DIFF
--- a/eval/_score_one_piece.py
+++ b/eval/_score_one_piece.py
@@ -1,0 +1,60 @@
+"""Subprocess worker for eval.score_demo_eval — scores one piece, prints JSON.
+
+This module is invoked as:
+    python -m eval._score_one_piece \\
+        --pred <predicted.musicxml> \\
+        --ref <reference.mxl> \\
+        --metrics tedn,linearized_ser,onset_f1
+
+It loads the metric libraries (music21, zss, mir_eval), computes the requested
+metrics, prints a single JSON line to stdout, then exits. The parent process
+(score_demo_eval.py) collects that JSON line.
+
+Keeping this in a separate module (rather than a -c snippet) means:
+- It can be imported/tested independently
+- The command line is readable in process listings
+- Stack traces on failure include file+line context
+
+Output contract:
+    On success: one JSON line {"onset_f1": <float|null>, "tedn": <float|null>,
+                               "linearized_ser": <float|null>}
+    On any exception: exits with code 1 (stderr has the traceback)
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--pred", type=Path, required=True)
+    p.add_argument("--ref", type=Path, required=True)
+    p.add_argument("--metrics", required=True, help="comma-separated metric names")
+    args = p.parse_args()
+
+    metrics = {m.strip() for m in args.metrics.split(",") if m.strip()}
+
+    result: dict = {"onset_f1": None, "tedn": None, "linearized_ser": None}
+
+    if "onset_f1" in metrics:
+        from eval.playback import playback_f
+        result["onset_f1"] = playback_f(pred=args.pred, gt=args.ref)["f"]
+
+    if "tedn" in metrics:
+        from eval.tedn import compute_tedn
+        result["tedn"] = compute_tedn(args.ref, args.pred)
+
+    if "linearized_ser" in metrics:
+        from eval.linearized_musicxml import compute_linearized_ser
+        result["linearized_ser"] = compute_linearized_ser(args.ref, args.pred)
+
+    # Print JSON as the last line of stdout — parent reads it
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/_score_one_piece.py
+++ b/eval/_score_one_piece.py
@@ -38,7 +38,7 @@ def main() -> None:
 
     metrics = {m.strip() for m in args.metrics.split(",") if m.strip()}
 
-    result: dict = {"onset_f1": None, "tedn": None, "linearized_ser": None}
+    result: dict = {}
 
     if "onset_f1" in metrics:
         from eval.playback import playback_f

--- a/eval/run_clarity_demo_eval.py
+++ b/eval/run_clarity_demo_eval.py
@@ -2,33 +2,41 @@
 demo pieces shown on the public HuggingFace model card
 (huggingface.co/clquwu/Clarity-OMR).
 
-Follows the exact same pattern as eval/run_lieder_eval.py — subprocess
-isolation for inference (model loads in a child process, dies when it exits)
-and explicit per-piece try/except to prevent one failure from aborting the
-run. This was deliberately chosen after a throwaway harness loaded the RADIO
-encoder + checkpoint in-process alongside music21/partitura metric parsing and
-committed 86 GB before the OS killed it.
+**Inference-only pass.** This script does NOT compute metrics. Its only job is
+to run the RADIO/YOLO inference pipeline for each piece and write the predicted
+MusicXML (plus optional Stage-D diagnostics sidecar) to disk. Metric scoring
+is handled by the separate eval/score_demo_eval.py, which subprocess-isolates
+per-piece metric computation so music21/zss memory is fully reclaimed after
+each piece.
+
+This two-pass design was adopted after Phase A profiling confirmed that metric
+scoring (music21 parse + ZSS tree edit distance for tedn; Levenshtein on large
+token sequences for linearized_ser) retains large object graphs not released
+between pieces, causing ~11 GB/min committed-memory growth that OOM-killed the
+process at 39 GB during Clair de Lune (908 KB MusicXML).
+
+Follows the exact same inference subprocess-isolation pattern as
+eval/run_lieder_eval.py — model loads in a child process, dies when it exits.
 
 Usage:
     venv-cu132\\Scripts\\python -m eval.run_clarity_demo_eval \\
         --checkpoint checkpoints/full_radio_stage2/stage2-radio-polyphonic_best.pt \\
         --config configs/train_stage2_radio.yaml \\
         --name stage2_best
+
+Then score:
+    venv-cu132\\Scripts\\python -m eval.score_demo_eval \\
+        --predictions-dir eval/results/clarity_demo_stage2_best \\
+        --reference-dir data/clarity_demo/mxl \\
+        --name stage2_best
 """
 import argparse
-import csv
-import json
-import statistics
 import sys
 from pathlib import Path
 
 # Insert repo root so imports work regardless of cwd
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_REPO_ROOT))
-
-from eval.playback import playback_f
-from eval.tedn import compute_tedn
-from eval.linearized_musicxml import compute_linearized_ser
 
 # Path to our venv's Python — used to invoke src.pdf_to_musicxml as a subprocess
 VENV_PYTHON = Path(__file__).resolve().parents[1] / "venv-cu132" / "Scripts" / "python.exe"
@@ -98,34 +106,11 @@ def run_inference(
     subprocess.run(cmd, check=True, cwd=str(repo_root), timeout=PDF_TO_MUSICXML_TIMEOUT_SEC)
 
 
-def _read_stage_d_diag(pred_path: Path) -> tuple:
-    """Return the 8 Stage-D diagnostic CSV values for *pred_path*.
-
-    Looks for <pred_path>.diagnostics.json alongside the MusicXML output.
-    Returns a tuple of 8 values (all None if the sidecar is absent or unreadable).
-    """
-    diag_path = pred_path.with_suffix(pred_path.suffix + ".diagnostics.json")
-    try:
-        raw = json.loads(diag_path.read_text(encoding="utf-8"))
-        raised = raw.get("raised_during_part_append", [])
-        first_error = raised[0].get("error_message", "") if raised else ""
-        return (
-            raw.get("skipped_notes"),
-            raw.get("skipped_chords"),
-            raw.get("missing_durations"),
-            raw.get("malformed_spans"),
-            raw.get("unknown_tokens"),
-            raw.get("fallback_rests"),
-            len(raised),
-            first_error,
-        )
-    except Exception:
-        return (None, None, None, None, None, None, None, None)
-
-
 def main() -> None:
     p = argparse.ArgumentParser(
-        description="Evaluate a Stage 2 checkpoint on the 4 canonical HF demo pieces."
+        description="Inference-only pass: run Stage B checkpoint on the 4 canonical "
+                    "HF demo pieces and write predicted MusicXML files to disk. "
+                    "Run eval/score_demo_eval.py afterwards to compute metrics."
     )
     p.add_argument(
         "--checkpoint", type=Path, required=True,
@@ -137,7 +122,7 @@ def main() -> None:
     )
     p.add_argument(
         "--name", required=True,
-        help="run name (used for output dir + CSV filename)",
+        help="run name (used for output dir: eval/results/clarity_demo_<name>/)",
     )
     p.add_argument(
         "--beam-width", type=int, default=1,
@@ -158,39 +143,32 @@ def main() -> None:
     print(f"Checkpoint: {args.checkpoint}")
     print(f"Config:     {args.config}")
     print(f"Pieces:     {len(DEMO_STEMS)}")
+    print(f"Mode:       INFERENCE ONLY (no metric scoring)")
     print()
 
     repo_root = Path(__file__).resolve().parents[1]
     pdf_dir = (repo_root / "data/clarity_demo/pdf").resolve()
-    mxl_dir = (repo_root / "data/clarity_demo/mxl").resolve()
     out_dir = (repo_root / "eval/results" / f"clarity_demo_{args.name}").resolve()
     work_base = (repo_root / "eval/results" / f"clarity_demo_{args.name}_workdirs").resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
 
     n_total = len(DEMO_STEMS)
-    # Each row: (piece, onset_f1, tedn, linearized_ser,
-    #            stage_d_skipped_notes, stage_d_skipped_chords,
-    #            stage_d_missing_durations, stage_d_malformed_spans,
-    #            stage_d_unknown_tokens, stage_d_fallback_rests,
-    #            stage_d_raised_count, stage_d_first_error)
-    rows: list = []
+    n_ok = 0
+    n_skip = 0
+    n_fail = 0
 
     for i, stem in enumerate(DEMO_STEMS, 1):
         pdf = pdf_dir / f"{stem}.pdf"
-        ref = mxl_dir / f"{stem}.mxl"
 
         if not pdf.exists():
             print(f"[{i}/{n_total}] SKIP {stem}: PDF not found at {pdf}")
-            rows.append((stem, None, None, None) + (None,) * 8)
-            continue
-        if not ref.exists():
-            print(f"[{i}/{n_total}] SKIP {stem}: reference MXL not found at {ref}")
-            rows.append((stem, None, None, None) + (None,) * 8)
+            n_skip += 1
             continue
 
+        pred = out_dir / f"{stem}.musicxml"
+        work_dir = work_base / stem
+
         try:
-            pred = out_dir / f"{stem}.musicxml"
-            work_dir = work_base / stem
             if not pred.exists():
                 print(f"[{i}/{n_total}] inference {stem} ...")
                 run_inference(
@@ -198,65 +176,30 @@ def main() -> None:
                     beam_width=args.beam_width,
                     max_decode_steps=args.max_decode_steps,
                 )
+                if pred.exists():
+                    print(f"[{i}/{n_total}] done     {stem}  ({pred.stat().st_size // 1024} KB)")
+                else:
+                    print(f"[{i}/{n_total}] WARN     {stem}: inference completed but output not found")
             else:
-                print(f"[{i}/{n_total}] cached  {stem}")
-
-            # Read Stage D diagnostics sidecar (written by src.pdf_to_musicxml).
-            stage_d_cols = _read_stage_d_diag(pred)
-
-            f1 = playback_f(pred=pred, gt=ref)["f"]
-            try:
-                tedn = compute_tedn(ref, pred)
-            except Exception as te:
-                print(f"[{i}/{n_total}]   tedn WARN {stem}: {te}")
-                tedn = None
-            try:
-                lin_ser = compute_linearized_ser(ref, pred)
-            except Exception as le:
-                print(f"[{i}/{n_total}]   lin_ser WARN {stem}: {le}")
-                lin_ser = None
-
-            rows.append((stem, f1, tedn, lin_ser) + stage_d_cols)
-            tedn_str = f"{tedn:.4f}" if tedn is not None else "N/A"
-            lin_str = f"{lin_ser:.4f}" if lin_ser is not None else "N/A"
-            print(
-                f"[{i}/{n_total}] {stem}: onset_f1={f1:.4f}  tedn={tedn_str}  lin_ser={lin_str}"
-            )
-
+                print(f"[{i}/{n_total}] cached   {stem}  ({pred.stat().st_size // 1024} KB)")
+            n_ok += 1
         except Exception as e:
             print(f"[{i}/{n_total}] FAIL {stem}: {type(e).__name__}: {e}")
-            rows.append((stem, None, None, None) + (None,) * 8)
+            n_fail += 1
 
-    csv_path = (repo_root / "eval/results" / f"clarity_demo_{args.name}.csv").resolve()
-    csv_path.parent.mkdir(parents=True, exist_ok=True)
-    with csv_path.open("w", newline="") as fh:
-        w = csv.writer(fh)
-        w.writerow([
-            "piece", "onset_f1", "tedn", "linearized_ser",
-            "stage_d_skipped_notes", "stage_d_skipped_chords",
-            "stage_d_missing_durations", "stage_d_malformed_spans",
-            "stage_d_unknown_tokens", "stage_d_fallback_rests",
-            "stage_d_raised_count", "stage_d_first_error",
-        ])
-        w.writerows(rows)
-    print(f"\nResults written to {csv_path}")
-
-    valid = [row[1] for row in rows if row[1] is not None]
-    failed_count = sum(1 for row in rows if row[1] is None)
-    if not valid:
-        print(f"\nNo pieces scored successfully ({failed_count}/{n_total} failed/skipped).")
-        return
-
-    mean_f1 = statistics.mean(valid)
-    med_f1 = statistics.median(valid)
-    min_f1 = min(valid)
-    max_f1 = max(valid)
-    print(f"\n=== Clarity Demo Eval Results ({args.name}) ===")
-    print(f"Pieces evaluated: {len(valid)} / {n_total} (failed/skipped: {failed_count})")
-    print(f"Mean onset-F1:   {mean_f1:.4f}")
-    print(f"Median onset-F1: {med_f1:.4f}")
-    print(f"Min onset-F1:    {min_f1:.4f}")
-    print(f"Max onset-F1:    {max_f1:.4f}")
+    print()
+    print(f"=== Inference complete ===")
+    print(f"  OK:      {n_ok}/{n_total}")
+    print(f"  Skipped: {n_skip}/{n_total}")
+    print(f"  Failed:  {n_fail}/{n_total}")
+    print()
+    print(f"Predicted XMLs written to: {out_dir}")
+    print()
+    print("Next step — run metric scoring:")
+    print(f"  venv-cu132\\Scripts\\python -m eval.score_demo_eval \\")
+    print(f"      --predictions-dir {out_dir} \\")
+    print(f"      --reference-dir {(repo_root / 'data/clarity_demo/mxl').resolve()} \\")
+    print(f"      --name {args.name}")
 
 
 if __name__ == "__main__":

--- a/eval/run_clarity_demo_eval.py
+++ b/eval/run_clarity_demo_eval.py
@@ -1,0 +1,263 @@
+"""Run a trained Clarity-OMR-Train-RADIO checkpoint against the 4 canonical
+demo pieces shown on the public HuggingFace model card
+(huggingface.co/clquwu/Clarity-OMR).
+
+Follows the exact same pattern as eval/run_lieder_eval.py — subprocess
+isolation for inference (model loads in a child process, dies when it exits)
+and explicit per-piece try/except to prevent one failure from aborting the
+run. This was deliberately chosen after a throwaway harness loaded the RADIO
+encoder + checkpoint in-process alongside music21/partitura metric parsing and
+committed 86 GB before the OS killed it.
+
+Usage:
+    venv-cu132\\Scripts\\python -m eval.run_clarity_demo_eval \\
+        --checkpoint checkpoints/full_radio_stage2/stage2-radio-polyphonic_best.pt \\
+        --config configs/train_stage2_radio.yaml \\
+        --name stage2_best
+"""
+import argparse
+import csv
+import json
+import statistics
+import sys
+from pathlib import Path
+
+# Insert repo root so imports work regardless of cwd
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from eval.playback import playback_f
+from eval.tedn import compute_tedn
+from eval.linearized_musicxml import compute_linearized_ser
+
+# Path to our venv's Python — used to invoke src.pdf_to_musicxml as a subprocess
+VENV_PYTHON = Path(__file__).resolve().parents[1] / "venv-cu132" / "Scripts" / "python.exe"
+
+# Stage A YOLO checkpoint is shipped by sibling Clarity-OMR (HuggingFace download
+# triggered on first omr.py run, lands at info/yolo.pt). We don't train Stage A
+# in this repo, so reuse it.
+STAGE_A_YOLO = Path.home() / "Clarity-OMR" / "info" / "yolo.pt"
+
+# Inference timeout: 30 minutes per piece (same cap as lieder eval)
+PDF_TO_MUSICXML_TIMEOUT_SEC = 1800
+
+# Canonical demo pieces (stems match filenames under data/clarity_demo/{pdf,mxl}/)
+# These are the 4 pieces showcased on huggingface.co/clquwu/Clarity-OMR
+DEMO_STEMS = [
+    "clair-de-lune-debussy",
+    "fugue-no-2-bwv-847-in-c-minor",
+    "gnossienne-no-1",
+    "prelude-in-d-flat-major-op31-no1-scriabin",
+]
+
+
+def run_inference(
+    checkpoint: Path,
+    config: Path,
+    pdf: Path,
+    out: Path,
+    work_dir: Path,
+    *,
+    beam_width: int = 1,
+    max_decode_steps: int = 256,
+) -> None:
+    """Run our trained Stage B + sibling YOLO Stage A on `pdf`, write MusicXML to `out`.
+
+    Spawns src.pdf_to_musicxml in a *child process* so that the RADIO encoder,
+    checkpoint weights, and all torch tensors are released when the child exits.
+    This is the key isolation that prevents the 86 GB committed-memory incident
+    from recurring.
+    """
+    import subprocess
+
+    if not STAGE_A_YOLO.exists():
+        raise SystemExit(
+            f"FATAL: Stage A YOLO weights not found at {STAGE_A_YOLO}. "
+            "Run sibling Clarity-OMR's omr.py once on any PDF to trigger the HF download."
+        )
+    repo_root = Path(__file__).resolve().parents[1]
+    work_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        str(VENV_PYTHON),
+        "-m", "src.pdf_to_musicxml",
+        "--pdf", str(pdf),
+        "--output-musicxml", str(out),
+        "--weights", str(STAGE_A_YOLO),
+        "--stage-b-checkpoint", str(checkpoint),
+        "--work-dir", str(work_dir),
+        "--project-root", str(repo_root),
+        "--stage-b-device", "cuda",
+        "--beam-width", str(beam_width),
+        "--max-decode-steps", str(max_decode_steps),
+        "--image-height", "250",
+        "--image-max-width", "2500",
+        "--length-penalty-alpha", "0.4",
+        "--pdf-dpi", "300",
+        "--quiet",
+    ]
+    subprocess.run(cmd, check=True, cwd=str(repo_root), timeout=PDF_TO_MUSICXML_TIMEOUT_SEC)
+
+
+def _read_stage_d_diag(pred_path: Path) -> tuple:
+    """Return the 8 Stage-D diagnostic CSV values for *pred_path*.
+
+    Looks for <pred_path>.diagnostics.json alongside the MusicXML output.
+    Returns a tuple of 8 values (all None if the sidecar is absent or unreadable).
+    """
+    diag_path = pred_path.with_suffix(pred_path.suffix + ".diagnostics.json")
+    try:
+        raw = json.loads(diag_path.read_text(encoding="utf-8"))
+        raised = raw.get("raised_during_part_append", [])
+        first_error = raised[0].get("error_message", "") if raised else ""
+        return (
+            raw.get("skipped_notes"),
+            raw.get("skipped_chords"),
+            raw.get("missing_durations"),
+            raw.get("malformed_spans"),
+            raw.get("unknown_tokens"),
+            raw.get("fallback_rests"),
+            len(raised),
+            first_error,
+        )
+    except Exception:
+        return (None, None, None, None, None, None, None, None)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Evaluate a Stage 2 checkpoint on the 4 canonical HF demo pieces."
+    )
+    p.add_argument(
+        "--checkpoint", type=Path, required=True,
+        help="path to trained Stage B .pt checkpoint",
+    )
+    p.add_argument(
+        "--config", type=Path, required=True,
+        help="path to .yaml config matching checkpoint",
+    )
+    p.add_argument(
+        "--name", required=True,
+        help="run name (used for output dir + CSV filename)",
+    )
+    p.add_argument(
+        "--beam-width", type=int, default=1,
+        help="Stage-B beam width (default 1 = greedy; matches lieder eval default)",
+    )
+    p.add_argument(
+        "--max-decode-steps", type=int, default=256,
+        help="Stage-B max decode steps per staff (default 256; matches lieder eval default)",
+    )
+    args = p.parse_args()
+
+    if not args.checkpoint.exists():
+        raise SystemExit(f"FATAL: checkpoint not found: {args.checkpoint}")
+    if not args.config.exists():
+        raise SystemExit(f"FATAL: config not found: {args.config}")
+
+    print(f"Run name:   {args.name}")
+    print(f"Checkpoint: {args.checkpoint}")
+    print(f"Config:     {args.config}")
+    print(f"Pieces:     {len(DEMO_STEMS)}")
+    print()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    pdf_dir = (repo_root / "data/clarity_demo/pdf").resolve()
+    mxl_dir = (repo_root / "data/clarity_demo/mxl").resolve()
+    out_dir = (repo_root / "eval/results" / f"clarity_demo_{args.name}").resolve()
+    work_base = (repo_root / "eval/results" / f"clarity_demo_{args.name}_workdirs").resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    n_total = len(DEMO_STEMS)
+    # Each row: (piece, onset_f1, tedn, linearized_ser,
+    #            stage_d_skipped_notes, stage_d_skipped_chords,
+    #            stage_d_missing_durations, stage_d_malformed_spans,
+    #            stage_d_unknown_tokens, stage_d_fallback_rests,
+    #            stage_d_raised_count, stage_d_first_error)
+    rows: list = []
+
+    for i, stem in enumerate(DEMO_STEMS, 1):
+        pdf = pdf_dir / f"{stem}.pdf"
+        ref = mxl_dir / f"{stem}.mxl"
+
+        if not pdf.exists():
+            print(f"[{i}/{n_total}] SKIP {stem}: PDF not found at {pdf}")
+            rows.append((stem, None, None, None) + (None,) * 8)
+            continue
+        if not ref.exists():
+            print(f"[{i}/{n_total}] SKIP {stem}: reference MXL not found at {ref}")
+            rows.append((stem, None, None, None) + (None,) * 8)
+            continue
+
+        try:
+            pred = out_dir / f"{stem}.musicxml"
+            work_dir = work_base / stem
+            if not pred.exists():
+                print(f"[{i}/{n_total}] inference {stem} ...")
+                run_inference(
+                    args.checkpoint, args.config, pdf, pred, work_dir,
+                    beam_width=args.beam_width,
+                    max_decode_steps=args.max_decode_steps,
+                )
+            else:
+                print(f"[{i}/{n_total}] cached  {stem}")
+
+            # Read Stage D diagnostics sidecar (written by src.pdf_to_musicxml).
+            stage_d_cols = _read_stage_d_diag(pred)
+
+            f1 = playback_f(pred=pred, gt=ref)["f"]
+            try:
+                tedn = compute_tedn(ref, pred)
+            except Exception as te:
+                print(f"[{i}/{n_total}]   tedn WARN {stem}: {te}")
+                tedn = None
+            try:
+                lin_ser = compute_linearized_ser(ref, pred)
+            except Exception as le:
+                print(f"[{i}/{n_total}]   lin_ser WARN {stem}: {le}")
+                lin_ser = None
+
+            rows.append((stem, f1, tedn, lin_ser) + stage_d_cols)
+            tedn_str = f"{tedn:.4f}" if tedn is not None else "N/A"
+            lin_str = f"{lin_ser:.4f}" if lin_ser is not None else "N/A"
+            print(
+                f"[{i}/{n_total}] {stem}: onset_f1={f1:.4f}  tedn={tedn_str}  lin_ser={lin_str}"
+            )
+
+        except Exception as e:
+            print(f"[{i}/{n_total}] FAIL {stem}: {type(e).__name__}: {e}")
+            rows.append((stem, None, None, None) + (None,) * 8)
+
+    csv_path = (repo_root / "eval/results" / f"clarity_demo_{args.name}.csv").resolve()
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    with csv_path.open("w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow([
+            "piece", "onset_f1", "tedn", "linearized_ser",
+            "stage_d_skipped_notes", "stage_d_skipped_chords",
+            "stage_d_missing_durations", "stage_d_malformed_spans",
+            "stage_d_unknown_tokens", "stage_d_fallback_rests",
+            "stage_d_raised_count", "stage_d_first_error",
+        ])
+        w.writerows(rows)
+    print(f"\nResults written to {csv_path}")
+
+    valid = [row[1] for row in rows if row[1] is not None]
+    failed_count = sum(1 for row in rows if row[1] is None)
+    if not valid:
+        print(f"\nNo pieces scored successfully ({failed_count}/{n_total} failed/skipped).")
+        return
+
+    mean_f1 = statistics.mean(valid)
+    med_f1 = statistics.median(valid)
+    min_f1 = min(valid)
+    max_f1 = max(valid)
+    print(f"\n=== Clarity Demo Eval Results ({args.name}) ===")
+    print(f"Pieces evaluated: {len(valid)} / {n_total} (failed/skipped: {failed_count})")
+    print(f"Mean onset-F1:   {mean_f1:.4f}")
+    print(f"Median onset-F1: {med_f1:.4f}")
+    print(f"Min onset-F1:    {min_f1:.4f}")
+    print(f"Max onset-F1:    {max_f1:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/score_demo_eval.py
+++ b/eval/score_demo_eval.py
@@ -7,10 +7,16 @@ Two-pass design:
   computation so each piece's music21/zss memory is fully reclaimed after the
   subprocess exits. The parent process stays small throughout.
 
-Each piece is scored in a fresh child process (eval._score_one_piece) that
-reads the predicted XML + reference MXL, computes the requested metrics, and
-prints a JSON line to stdout. The parent collects those lines into the final
-CSV.
+Each piece is scored in up to TWO fresh child processes (eval._score_one_piece):
+
+  1. Cheap pair (onset_f1 + linearized_ser): 60 s timeout. These metrics finish
+     in <2 s even for large scores (<=43 MB data) and are always attempted first.
+  2. Tedn-only: 300 s timeout.  May time out for very large scores (Clair de
+     Lune peaks >37 GB); when it does the cheap metrics are still recovered.
+
+If only cheap metrics were requested (or only tedn), a single subprocess is
+used.  The split only activates when the requested set includes both tedn and
+at least one cheap metric.
 
 Usage:
     venv-cu132\\Scripts\\python -m eval.score_demo_eval \\
@@ -31,13 +37,22 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_REPO_ROOT))
 
-# Path to our venv's Python — same one that ran inference
+# Path to our venv's Python -- same one that ran inference
 VENV_PYTHON = Path(__file__).resolve().parents[1] / "venv-cu132" / "Scripts" / "python.exe"
 
-# Per-piece subprocess timeout: 5 minutes is generous even for large scores
-SCORE_TIMEOUT_SEC = 300
+# Timeout for the cheap-pair subprocess (onset_f1 + linearized_ser)
+CHEAP_TIMEOUT_SEC = 60
 
-# Canonical demo stems — must match run_clarity_demo_eval.py
+# Timeout for tedn (may OOM/hang on very large scores like Clair de Lune)
+TEDN_TIMEOUT_SEC = 300
+
+# Backward-compat alias
+SCORE_TIMEOUT_SEC = TEDN_TIMEOUT_SEC
+
+# Metrics considered "cheap" -- fast and low-memory
+CHEAP_METRICS = frozenset({"onset_f1", "linearized_ser"})
+
+# Canonical demo stems -- must match run_clarity_demo_eval.py
 DEMO_STEMS = [
     "clair-de-lune-debussy",
     "fugue-no-2-bwv-847-in-c-minor",
@@ -76,19 +91,17 @@ def _read_stage_d_diag(pred_path: Path) -> tuple:
         return (None, None, None, None, None, None, None, None)
 
 
-def score_piece_subprocess(
-    stem: str,
+def _run_subprocess(
     pred_path: Path,
     ref_path: Path,
     metrics: list[str],
+    timeout: int,
 ) -> dict:
-    """Run eval._score_one_piece in a subprocess; return parsed JSON dict.
+    """Run eval._score_one_piece in a subprocess and return the parsed JSON dict.
 
-    On success: returns dict with keys onset_f1, tedn, linearized_ser (any
-    metric not in `metrics` list will be None).
-
-    On failure (timeout, crash, bad JSON): returns dict with all metric keys
-    set to None and 'error' key set to a short description string.
+    On success: returns dict with metric keys populated.
+    On failure (timeout, crash, bad JSON): returns dict with 'error' key set to
+    a short description string.
     """
     cmd = [
         str(VENV_PYTHON), "-m", "eval._score_one_piece",
@@ -102,24 +115,85 @@ def score_piece_subprocess(
             cmd,
             capture_output=True,
             text=True,
-            timeout=SCORE_TIMEOUT_SEC,
+            timeout=timeout,
             cwd=str(repo_root),
         )
         if result.returncode != 0:
             stderr_snippet = (result.stderr or "")[-500:].strip()
             return {"error": f"subprocess exit {result.returncode}: {stderr_snippet}"}
         # Last non-empty line of stdout should be the JSON payload
-        lines = [l.strip() for l in result.stdout.splitlines() if l.strip()]
+        lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
         if not lines:
             return {"error": "subprocess produced no output"}
         payload = json.loads(lines[-1])
         return payload
     except subprocess.TimeoutExpired:
-        return {"error": f"subprocess timeout after {SCORE_TIMEOUT_SEC}s"}
+        return {"error": f"subprocess timeout after {timeout}s"}
     except json.JSONDecodeError as e:
         return {"error": f"JSON decode error: {e}"}
     except Exception as e:
         return {"error": f"{type(e).__name__}: {e}"}
+
+
+def score_piece_subprocess(
+    stem: str,
+    pred_path: Path,
+    ref_path: Path,
+    metrics: list[str],
+) -> dict:
+    """Score one piece, splitting cheap and tedn metrics into separate subprocesses.
+
+    When *metrics* contains both tedn and at least one cheap metric
+    (onset_f1 / linearized_ser), two subprocess calls are made:
+
+      1. Cheap pair (onset_f1 + linearized_ser present in *metrics*) with a
+         60 s timeout.
+      2. Tedn-only with a 300 s timeout.
+
+    The results are merged into a single dict.  Partial failures are surfaced in
+    the 'error' key with a prefix indicating which group failed, e.g.
+    "tedn: subprocess timeout after 300s".  If both groups fail the reasons are
+    joined with " | ".
+
+    When *metrics* is a strict subset of one group (e.g. only tedn, or only
+    onset_f1), a single subprocess call is used with the appropriate timeout.
+
+    Returns a dict with metric-value keys plus optionally an 'error' key
+    describing any failure(s).
+    """
+    cheap_requested = [m for m in metrics if m in CHEAP_METRICS]
+    tedn_requested = [m for m in metrics if m == "tedn"]
+
+    # Decide whether to split into two calls
+    need_split = bool(cheap_requested) and bool(tedn_requested)
+
+    if not need_split:
+        # Single call -- use appropriate timeout
+        timeout = CHEAP_TIMEOUT_SEC if not tedn_requested else TEDN_TIMEOUT_SEC
+        return _run_subprocess(pred_path, ref_path, metrics, timeout)
+
+    # --- Split path: two subprocess calls ---
+    combined: dict = {}
+    failure_parts: list[str] = []
+
+    # 1. Cheap pair
+    cheap_result = _run_subprocess(pred_path, ref_path, cheap_requested, CHEAP_TIMEOUT_SEC)
+    if "error" in cheap_result:
+        failure_parts.append(f"cheap-pair: {cheap_result['error']}")
+    else:
+        combined.update({k: v for k, v in cheap_result.items() if k != "error"})
+
+    # 2. Tedn-only
+    tedn_result = _run_subprocess(pred_path, ref_path, tedn_requested, TEDN_TIMEOUT_SEC)
+    if "error" in tedn_result:
+        failure_parts.append(f"tedn: {tedn_result['error']}")
+    else:
+        combined.update({k: v for k, v in tedn_result.items() if k != "error"})
+
+    if failure_parts:
+        combined["error"] = " | ".join(failure_parts)
+
+    return combined
 
 
 def main() -> None:
@@ -157,11 +231,21 @@ def main() -> None:
     if unknown:
         raise SystemExit(f"FATAL: unknown metrics: {unknown}. Valid: {valid_metrics}")
 
+    cheap_requested = [m for m in metrics if m in CHEAP_METRICS]
+    tedn_requested = [m for m in metrics if m == "tedn"]
+    splitting = bool(cheap_requested) and bool(tedn_requested)
+
     print(f"Run name:        {args.name}")
     print(f"Predictions dir: {args.predictions_dir}")
     print(f"Reference dir:   {args.reference_dir}")
     print(f"Metrics:         {metrics}")
     print(f"Pieces:          {len(DEMO_STEMS)}")
+    if splitting:
+        print(f"Scoring mode:    split (cheap={cheap_requested} @{CHEAP_TIMEOUT_SEC}s,"
+              f" tedn @{TEDN_TIMEOUT_SEC}s)")
+    else:
+        timeout = CHEAP_TIMEOUT_SEC if not tedn_requested else TEDN_TIMEOUT_SEC
+        print(f"Scoring mode:    single subprocess @{timeout}s")
     print()
 
     repo_root = Path(__file__).resolve().parents[1]
@@ -186,8 +270,10 @@ def main() -> None:
         # Stage D diagnostics are read in-process (fast JSON read, no music21)
         stage_d_cols = _read_stage_d_diag(pred)
 
-        # Metric scoring runs in a subprocess — OS reclaims all music21/zss memory
+        # Metric scoring runs in subprocess(es) -- OS reclaims all music21/zss memory
         # when the child exits, preventing the 86 GB committed-memory OOM seen in v1.
+        # cheap metrics and tedn are split into separate calls so a tedn timeout
+        # does not discard already-computed onset_f1 / linearized_ser values.
         payload = score_piece_subprocess(stem, pred, ref, metrics)
 
         failure_reason = payload.get("error", None)
@@ -197,12 +283,14 @@ def main() -> None:
 
         rows.append((stem, f1, tedn, lin_ser) + stage_d_cols + (failure_reason,))
 
+        tedn_str = f"{tedn:.4f}" if tedn is not None else "N/A"
+        lin_str = f"{lin_ser:.4f}" if lin_ser is not None else "N/A"
+        f1_str = f"{f1:.4f}" if f1 is not None else "N/A"
         if failure_reason:
-            print(f"[{i}/{n_total}] FAIL {stem}: {failure_reason}")
+            # Partial success: some metrics may still be populated
+            print(f"[{i}/{n_total}] PARTIAL/FAIL {stem}: {failure_reason}")
+            print(f"             onset_f1={f1_str}  tedn={tedn_str}  lin_ser={lin_str}")
         else:
-            tedn_str = f"{tedn:.4f}" if tedn is not None else "N/A"
-            lin_str = f"{lin_ser:.4f}" if lin_ser is not None else "N/A"
-            f1_str = f"{f1:.4f}" if f1 is not None else "N/A"
             print(f"[{i}/{n_total}] {stem}: onset_f1={f1_str}  tedn={tedn_str}  lin_ser={lin_str}")
 
     csv_path = (repo_root / "eval/results" / f"clarity_demo_{args.name}.csv").resolve()

--- a/eval/score_demo_eval.py
+++ b/eval/score_demo_eval.py
@@ -1,0 +1,235 @@
+"""Score per-piece metric results for the 4 canonical demo pieces.
+
+Two-pass design:
+- Pass 1 (run_clarity_demo_eval.py): inference only — writes predicted MusicXML
+  and optional diagnostics sidecars to --predictions-dir.
+- Pass 2 (this script): scoring only — subprocess-isolates per-piece metric
+  computation so each piece's music21/zss memory is fully reclaimed after the
+  subprocess exits. The parent process stays small throughout.
+
+Each piece is scored in a fresh child process (eval._score_one_piece) that
+reads the predicted XML + reference MXL, computes the requested metrics, and
+prints a JSON line to stdout. The parent collects those lines into the final
+CSV.
+
+Usage:
+    venv-cu132\\Scripts\\python -m eval.score_demo_eval \\
+        --predictions-dir eval/results/clarity_demo_stage2_best \\
+        --reference-dir data/clarity_demo/mxl \\
+        --name stage2_best
+
+Output: eval/results/clarity_demo_<name>.csv
+"""
+import argparse
+import csv
+import json
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+# Path to our venv's Python — same one that ran inference
+VENV_PYTHON = Path(__file__).resolve().parents[1] / "venv-cu132" / "Scripts" / "python.exe"
+
+# Per-piece subprocess timeout: 5 minutes is generous even for large scores
+SCORE_TIMEOUT_SEC = 300
+
+# Canonical demo stems — must match run_clarity_demo_eval.py
+DEMO_STEMS = [
+    "clair-de-lune-debussy",
+    "fugue-no-2-bwv-847-in-c-minor",
+    "gnossienne-no-1",
+    "prelude-in-d-flat-major-op31-no1-scriabin",
+]
+
+CSV_HEADER = [
+    "piece", "onset_f1", "tedn", "linearized_ser",
+    "stage_d_skipped_notes", "stage_d_skipped_chords",
+    "stage_d_missing_durations", "stage_d_malformed_spans",
+    "stage_d_unknown_tokens", "stage_d_fallback_rests",
+    "stage_d_raised_count", "stage_d_first_error",
+    "score_failure_reason",
+]
+
+
+def _read_stage_d_diag(pred_path: Path) -> tuple:
+    """Return the 8 Stage-D diagnostic CSV values for *pred_path*."""
+    diag_path = pred_path.with_suffix(pred_path.suffix + ".diagnostics.json")
+    try:
+        raw = json.loads(diag_path.read_text(encoding="utf-8"))
+        raised = raw.get("raised_during_part_append", [])
+        first_error = raised[0].get("error_message", "") if raised else ""
+        return (
+            raw.get("skipped_notes"),
+            raw.get("skipped_chords"),
+            raw.get("missing_durations"),
+            raw.get("malformed_spans"),
+            raw.get("unknown_tokens"),
+            raw.get("fallback_rests"),
+            len(raised),
+            first_error,
+        )
+    except Exception:
+        return (None, None, None, None, None, None, None, None)
+
+
+def score_piece_subprocess(
+    stem: str,
+    pred_path: Path,
+    ref_path: Path,
+    metrics: list[str],
+) -> dict:
+    """Run eval._score_one_piece in a subprocess; return parsed JSON dict.
+
+    On success: returns dict with keys onset_f1, tedn, linearized_ser (any
+    metric not in `metrics` list will be None).
+
+    On failure (timeout, crash, bad JSON): returns dict with all metric keys
+    set to None and 'error' key set to a short description string.
+    """
+    cmd = [
+        str(VENV_PYTHON), "-m", "eval._score_one_piece",
+        "--pred", str(pred_path),
+        "--ref", str(ref_path),
+        "--metrics", ",".join(metrics),
+    ]
+    repo_root = Path(__file__).resolve().parents[1]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=SCORE_TIMEOUT_SEC,
+            cwd=str(repo_root),
+        )
+        if result.returncode != 0:
+            stderr_snippet = (result.stderr or "")[-500:].strip()
+            return {"error": f"subprocess exit {result.returncode}: {stderr_snippet}"}
+        # Last non-empty line of stdout should be the JSON payload
+        lines = [l.strip() for l in result.stdout.splitlines() if l.strip()]
+        if not lines:
+            return {"error": "subprocess produced no output"}
+        payload = json.loads(lines[-1])
+        return payload
+    except subprocess.TimeoutExpired:
+        return {"error": f"subprocess timeout after {SCORE_TIMEOUT_SEC}s"}
+    except json.JSONDecodeError as e:
+        return {"error": f"JSON decode error: {e}"}
+    except Exception as e:
+        return {"error": f"{type(e).__name__}: {e}"}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Score predicted MusicXMLs against reference MXLs, "
+                    "subprocess-isolating per-piece metric computation."
+    )
+    p.add_argument(
+        "--predictions-dir", type=Path, required=True,
+        help="Directory containing predicted .musicxml files (output of run_clarity_demo_eval.py)",
+    )
+    p.add_argument(
+        "--reference-dir", type=Path, required=True,
+        help="Directory containing reference .mxl files",
+    )
+    p.add_argument(
+        "--name", required=True,
+        help="Run name (used for output CSV filename: eval/results/clarity_demo_<name>.csv)",
+    )
+    p.add_argument(
+        "--metrics",
+        default="tedn,linearized_ser,onset_f1",
+        help="Comma-separated list of metrics to compute (default: tedn,linearized_ser,onset_f1)",
+    )
+    args = p.parse_args()
+
+    if not args.predictions_dir.exists():
+        raise SystemExit(f"FATAL: predictions-dir not found: {args.predictions_dir}")
+    if not args.reference_dir.exists():
+        raise SystemExit(f"FATAL: reference-dir not found: {args.reference_dir}")
+
+    metrics = [m.strip() for m in args.metrics.split(",") if m.strip()]
+    valid_metrics = {"tedn", "linearized_ser", "onset_f1"}
+    unknown = set(metrics) - valid_metrics
+    if unknown:
+        raise SystemExit(f"FATAL: unknown metrics: {unknown}. Valid: {valid_metrics}")
+
+    print(f"Run name:        {args.name}")
+    print(f"Predictions dir: {args.predictions_dir}")
+    print(f"Reference dir:   {args.reference_dir}")
+    print(f"Metrics:         {metrics}")
+    print(f"Pieces:          {len(DEMO_STEMS)}")
+    print()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    n_total = len(DEMO_STEMS)
+    rows: list[tuple] = []
+
+    for i, stem in enumerate(DEMO_STEMS, 1):
+        pred = args.predictions_dir / f"{stem}.musicxml"
+        ref = args.reference_dir / f"{stem}.mxl"
+
+        if not pred.exists():
+            print(f"[{i}/{n_total}] SKIP {stem}: predicted XML not found at {pred}")
+            rows.append((stem, None, None, None) + (None,) * 8 + ("predicted_xml_missing",))
+            continue
+        if not ref.exists():
+            print(f"[{i}/{n_total}] SKIP {stem}: reference MXL not found at {ref}")
+            rows.append((stem, None, None, None) + (None,) * 8 + ("reference_mxl_missing",))
+            continue
+
+        print(f"[{i}/{n_total}] scoring {stem} ...")
+
+        # Stage D diagnostics are read in-process (fast JSON read, no music21)
+        stage_d_cols = _read_stage_d_diag(pred)
+
+        # Metric scoring runs in a subprocess — OS reclaims all music21/zss memory
+        # when the child exits, preventing the 86 GB committed-memory OOM seen in v1.
+        payload = score_piece_subprocess(stem, pred, ref, metrics)
+
+        failure_reason = payload.get("error", None)
+        f1 = payload.get("onset_f1") if "onset_f1" in metrics else None
+        tedn = payload.get("tedn") if "tedn" in metrics else None
+        lin_ser = payload.get("linearized_ser") if "linearized_ser" in metrics else None
+
+        rows.append((stem, f1, tedn, lin_ser) + stage_d_cols + (failure_reason,))
+
+        if failure_reason:
+            print(f"[{i}/{n_total}] FAIL {stem}: {failure_reason}")
+        else:
+            tedn_str = f"{tedn:.4f}" if tedn is not None else "N/A"
+            lin_str = f"{lin_ser:.4f}" if lin_ser is not None else "N/A"
+            f1_str = f"{f1:.4f}" if f1 is not None else "N/A"
+            print(f"[{i}/{n_total}] {stem}: onset_f1={f1_str}  tedn={tedn_str}  lin_ser={lin_str}")
+
+    csv_path = (repo_root / "eval/results" / f"clarity_demo_{args.name}.csv").resolve()
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    with csv_path.open("w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(CSV_HEADER)
+        w.writerows(rows)
+    print(f"\nResults written to {csv_path}")
+
+    valid = [row[1] for row in rows if row[1] is not None]
+    failed_count = sum(1 for row in rows if row[1] is None)
+    if not valid:
+        print(f"\nNo pieces scored successfully ({failed_count}/{n_total} failed/skipped).")
+        return
+
+    mean_f1 = statistics.mean(valid)
+    med_f1 = statistics.median(valid)
+    min_f1 = min(valid)
+    max_f1 = max(valid)
+    print(f"\n=== Clarity Demo Scoring Results ({args.name}) ===")
+    print(f"Pieces evaluated: {len(valid)} / {n_total} (failed/skipped: {failed_count})")
+    print(f"Mean onset-F1:   {mean_f1:.4f}")
+    print(f"Median onset-F1: {med_f1:.4f}")
+    print(f"Min onset-F1:    {min_f1:.4f}")
+    print(f"Max onset-F1:    {max_f1:.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `eval/run_clarity_demo_eval.py` (inference) + `eval/score_demo_eval.py` (scoring) + `eval/_score_one_piece.py` (subprocess worker) for evaluating a Stage 2 / Stage 3 checkpoint against the 4 canonical demo pieces shown on the public HuggingFace model card (`huggingface.co/clquwu/Clarity-OMR`):

- `clair-de-lune-debussy`
- `fugue-no-2-bwv-847-in-c-minor`
- `gnossienne-no-1`
- `prelude-in-d-flat-major-op31-no1-scriabin`

## Two-pass design

Pass 1 (`run_clarity_demo_eval.py`): inference only — single Python process, RADIO model loaded once, iterates pieces, writes predicted MusicXML + Stage D diagnostics sidecar to disk. Mirrors `eval/run_lieder_eval.py`'s pattern.

Pass 2 (`score_demo_eval.py`): scoring only — subprocess-isolates per-piece metric computation. Each piece gets up to two subprocess calls:
- Cheap pair (`onset_f1` + `linearized_ser`) with 60s timeout — finishes <2s on all sizes
- `tedn`-only with 300s timeout — may OOM/hang on very large scores

Splitting the calls means a tedn timeout doesn't discard the cheap metrics. Outputs CSV matching `run_lieder_eval`'s schema + `score_failure_reason`.

## Motivation

Two earlier in-process attempts to score the 4 pieces both OOM'd while scoring Clair de Lune (largest predicted MusicXML at 887 KB):
- v1 (throwaway harness): 86 GB committed, killed
- v2 (single-pass `run_clarity_demo_eval.py` modeled on lieder eval): 39 GB committed, killed at ~13 min

Phase A profiling identified `compute_tedn` (ZSS `simple_distance`) as the sole culprit — it allocates an O(n×m) cost matrix on the two score trees. `onset_f1` and `linearized_ser` are both <50 MB. Filed as #27 for follow-up (consider replacing ZSS with `apted` or a token-budget cutoff).

## Test plan

- [x] Stage 2 `_best.pt` end-to-end run on the 4 demo pieces, with memory monitoring
- [x] Verify `eval/results/clarity_demo_stage2_best.csv` has 4 rows + correct column set
- [x] Verify Clair de Lune still recovers `onset_f1` + `linearized_ser` after tedn timeout
- [ ] Re-run after Stage 3 finishes and compare deltas

## Stage 2 results

| Piece | onset_f1 | tedn | linearized_ser |
|---|---|---|---|
| clair-de-lune-debussy | 0.0282 | *timeout* | 1.1699 |
| fugue-no-2-bwv-847-in-c-minor | 0.0538 | 1.0826 | 0.8686 |
| gnossienne-no-1 | 0.1044 | 0.9529 | 0.8431 |
| prelude-in-d-flat-major-op31-no1-scriabin | 0.0265 | 1.5062 | 1.2078 |

Mean onset_f1: 0.0532 (low — Stage 2 trained on lieder corpus, demo pieces are denser polyphonic works; Stage 3 will be the meaningful comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)