### PR TITLE
feat(train): default --torch-compile to ON

### DIFF
--- a/src/train/train.py
+++ b/src/train/train.py
@@ -2462,13 +2462,13 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--torch-compile",
-        action="store_true",
-        default=False,
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help=(
-            "Apply torch.compile to the Stage-B decoder + positional_bridge "
-            "submodules (NOT the RADIO encoder — trust_remote_code makes that "
-            "fragile). Default off; first 50-100 opt-steps will be slow due to "
-            "compilation. Profile WITH and WITHOUT before adopting."
+            "Compile decoder + bridge modules with torch.compile. Default ON. "
+            "Pass --no-torch-compile to disable (e.g., for debugging or environments "
+            "that fail to compile). Encoder is excluded (RADIO uses trust_remote_code). "
+            "Bench: -0.7% wall on cu132 nightly + RTX 5090 (Phase 4.2 of cu132 rollout)."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

Flips `--torch-compile` from opt-in (`action='store_true', default=False`) to default-on (`BooleanOptionalAction, default=True`), as recommended by the 2026-04-27 cleanup plan.

### Motivation

Phase 4.2 of the cu132 rollout (`docs/perf/2026-04-27-cu132-rollout.md`) measured a **-0.7% wall improvement** on RTX 5090 + cu132 nightly torch over 350 steady-state opt-steps. The improvement is small but consistent and free; making it the default eliminates foot-guns where new launchers forget to opt in.

### Changes

- `src/train/train.py`: `--torch-compile` argparse entry converted from `action='store_true', default=False` to `action=argparse.BooleanOptionalAction, default=True`. Help text updated to reflect new semantics and bench data point.

### Opt-out

Pass `--no-torch-compile` to disable — e.g., for debugging, environments where `torch.compile` fails to trace, or isolated bench runs. The encoder remains excluded (RADIO uses `trust_remote_code`).

### Cleanup plan override

The cleanup plan flagged `--torch-compile` as "currently opt-in; bench first then consider default-on." Phase 4.2 completed that bench. This PR acts on the conclusion.

### Stage 3 not affected

Stage 3 training (PID 18400, currently in flight on the Windows host) was launched with `--torch-compile` set explicitly in the invocation. This PR does not affect that run — the process loaded `train.py` at startup and will not re-read it.

### Launchers

None of the five tracked launchers (`full_radio_stage1_inner.ps1`, `full_radio_stage2_inner.ps1`, `full_radio_stage3_inner.ps1`, `mvp_inner.ps1`, `index_full_inner.ps1`) currently pass `--torch-compile` in the tracked version on main, so no launcher changes were needed — the new default is sufficient.

### Tests

All four tests in `tests/test_torch_compile_flag.py` pass unchanged:
- `test_disabled_returns_model_unchanged` — calls helper directly with `enabled=False`; unaffected by argparse default.
- `test_enabled_compiles_only_decoder_and_bridge` — calls helper directly with `enabled=True`; unaffected.
- `test_missing_attrs_are_tolerated` — calls helper directly with `enabled=True`; unaffected.
- `test_help_mentions_torch_compile_flag` — asserts `"--torch-compile" in captured.out`; `BooleanOptionalAction` still advertises `--torch-compile` in help output.

**Do not merge without review.**