### PR TITLE
feat(eval): two-pass run_lieder_eval (mirrors demo eval pattern)

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -3,25 +3,91 @@
 Vendored from the score-ingest Phase 0 cross-check (validated bit-equivalent to
 upstream Clarity-OMR's eval.py -- gist 9992cca340).
 
+## Two-pass design (both demo and lieder evals)
+
+All full evals use a **two-pass** design to prevent music21/zss state from
+accumulating across pieces:
+
+1. **Inference pass** — runs the RADIO/YOLO pipeline per piece, writes predicted
+   MusicXML + Stage-D diagnostics sidecars to disk, then exits cleanly.
+2. **Scoring pass** — subprocess-isolates per-piece metric computation (cheap
+   metrics @60 s, tedn @300 s) so the OS reclaims all memory after each child
+   exits.  The parent process stays small regardless of corpus size.
+
+This design was adopted after Phase A profiling confirmed that in-process scoring
+causes ~11 GB/min committed-memory growth.  A 20-piece lieder run hit 43 GB at
+piece 6 and was killed before pagefile exhaustion (the demo eval OOM at 39 GB
+was the same root cause — see PR #26).
+
+### Shared infrastructure
+
+`eval/_scoring_utils.py` contains the subprocess dispatch logic used by both
+`score_demo_eval.py` and `score_lieder_eval.py`:
+
+- `score_piece_subprocess()` — splits cheap vs tedn into separate child
+  processes with independent timeouts
+- `_run_subprocess()` — invokes `eval._score_one_piece`, parses JSON result
+- `_read_stage_d_diag()` — reads the `.diagnostics.json` sidecar (in-process,
+  no music21)
+- `CSV_HEADER` — canonical column list shared by both CSV outputs
+
 ## Files
 
-- `playback.py` -- primary metric, mir_eval onset-only F1 with stripTies canonicalization
-- `canonicalize.py` -- MusicXML normalization (parts -> P1, P2, ...; stripTies; etc.)
-- `upstream_eval.py` -- author's eval.py vendored verbatim, used as the cross-check reference
-- `lieder_split.py` -- defines the OpenScore Lieder held-out 10% split (Task 9)
-- `run_baseline_reproduction.py` -- runs author's DaViT checkpoint through our pipeline; must match published numbers within +/-0.05 (Task 10)
-- `run_lieder_eval.py` -- full Lieder eval, both encoders (Task 11)
-- `run_clarity_demo_eval.py` -- inference pass for the 4-piece public comparison table (PR #26)
-- `score_demo_eval.py` -- scoring pass for the 4-piece results; subprocess-isolated per piece
+- `playback.py` — primary metric, mir_eval onset-only F1 with stripTies canonicalization
+- `canonicalize.py` — MusicXML normalization (parts -> P1, P2, ...; stripTies; etc.)
+- `upstream_eval.py` — author's eval.py vendored verbatim, used as the cross-check reference
+- `lieder_split.py` — defines the OpenScore Lieder held-out 10% split (Task 9)
+- `_scoring_utils.py` — shared subprocess-isolated scoring infrastructure (PR E)
+- `_score_one_piece.py` — subprocess worker: loads music21/zss, scores one piece, prints JSON
+- `run_baseline_reproduction.py` — runs author's DaViT checkpoint through our pipeline; must match published numbers within +/-0.05 (Task 10)
+- `run_clarity_demo_eval.py` — **inference pass** for the 4-piece public comparison table (PR #26)
+- `score_demo_eval.py` — **scoring pass** for the 4-piece results; subprocess-isolated per piece
+- `run_lieder_eval.py` — **inference pass** for the Lieder eval split (PR E)
+- `score_lieder_eval.py` — **scoring pass** for the Lieder results; subprocess-isolated per piece (PR E)
 
-## To re-run
+## Running the evals
+
+### Lieder eval (146-piece corpus, two-pass)
+
+```bash
+# Pass 1: inference (writes predicted MusicXML to eval/results/lieder_<name>/)
+venv\Scripts\python -m eval.run_lieder_eval \
+    --checkpoint checkpoints/stage3/best.pt \
+    --config configs/train_stage3.yaml \
+    --name stage3 \
+    --max-pieces 20    # optional: smoke-cap before full run
+
+# Pass 2: scoring (subprocess-isolated per piece)
+venv\Scripts\python -m eval.score_lieder_eval \
+    --predictions-dir eval/results/lieder_stage3 \
+    --reference-dir data/openscore_lieder/scores \
+    --name stage3
+```
+
+Output CSV: `eval/results/lieder_stage3.csv`
+
+### Demo eval (4-piece public comparison table, two-pass)
+
+```bash
+# Pass 1: inference
+venv-cu132\Scripts\python -m eval.run_clarity_demo_eval \
+    --checkpoint checkpoints/stage3/best.pt \
+    --config configs/train_stage3.yaml \
+    --name stage3
+
+# Pass 2: scoring
+venv-cu132\Scripts\python -m eval.score_demo_eval \
+    --predictions-dir eval/results/clarity_demo_stage3 \
+    --reference-dir data/clarity_demo/mxl \
+    --name stage3
+```
+
+Output CSV: `eval/results/clarity_demo_stage3.csv`
+
+### Baseline reproduction
 
 ```bash
 python -m eval.run_baseline_reproduction
-python -m eval.run_lieder_eval --checkpoint <path>
-# 4-piece demo eval uses a two-pass design (inference then scoring):
-python -m eval.run_clarity_demo_eval --checkpoint <path> --out-dir eval/results/demo
-python -m eval.score_demo_eval --results-dir eval/results/demo
 ```
 
 Results land in `eval/results/`.

--- a/eval/_scoring_utils.py
+++ b/eval/_scoring_utils.py
@@ -1,0 +1,188 @@
+"""Shared subprocess-isolated scoring infrastructure for both demo and lieder evals.
+
+Imported by eval.score_demo_eval and eval.score_lieder_eval.  Contains:
+
+  - CSV_HEADER              — canonical column list (piece + metrics + stage_d + failure)
+  - _read_stage_d_diag()   — reads <pred>.diagnostics.json sidecar, returns 8-tuple
+  - _run_subprocess()      — invokes eval._score_one_piece, returns parsed JSON dict
+  - score_piece_subprocess() — splits cheap / tedn into separate subprocesses
+
+The split design is:
+  1. Cheap pair (onset_f1 + linearized_ser): CHEAP_TIMEOUT_SEC (60 s)
+  2. Tedn-only: TEDN_TIMEOUT_SEC (300 s)
+
+When both groups are requested, two child processes are launched so that a tedn
+timeout or OOM does not discard already-computed onset_f1 / linearized_ser.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+# Path to our venv's Python -- same one that ran inference.
+# score_demo_eval uses venv-cu132; lieder eval uses venv.
+# Callers can override by passing venv_python explicitly.
+_DEFAULT_VENV_PYTHON = Path(__file__).resolve().parents[1] / "venv-cu132" / "Scripts" / "python.exe"
+
+# Timeout for the cheap-pair subprocess (onset_f1 + linearized_ser)
+CHEAP_TIMEOUT_SEC = 60
+
+# Timeout for tedn (may OOM/hang on very large scores like Clair de Lune)
+TEDN_TIMEOUT_SEC = 300
+
+# Metrics considered "cheap" -- fast and low-memory
+CHEAP_METRICS = frozenset({"onset_f1", "linearized_ser"})
+
+# Canonical CSV header shared by demo and lieder CSVs
+CSV_HEADER = [
+    "piece", "onset_f1", "tedn", "linearized_ser",
+    "stage_d_skipped_notes", "stage_d_skipped_chords",
+    "stage_d_missing_durations", "stage_d_malformed_spans",
+    "stage_d_unknown_tokens", "stage_d_fallback_rests",
+    "stage_d_raised_count", "stage_d_first_error",
+    "score_failure_reason",
+]
+
+
+def _read_stage_d_diag(pred_path: Path) -> tuple:
+    """Return the 8 Stage-D diagnostic CSV values for *pred_path*.
+
+    Looks for <pred_path>.diagnostics.json alongside the MusicXML output.
+    Returns a tuple of 8 values (all None if the sidecar is absent or unreadable).
+    """
+    diag_path = pred_path.with_suffix(pred_path.suffix + ".diagnostics.json")
+    try:
+        raw = json.loads(diag_path.read_text(encoding="utf-8"))
+        raised = raw.get("raised_during_part_append", [])
+        first_error = raised[0].get("error_message", "") if raised else ""
+        return (
+            raw.get("skipped_notes"),
+            raw.get("skipped_chords"),
+            raw.get("missing_durations"),
+            raw.get("malformed_spans"),
+            raw.get("unknown_tokens"),
+            raw.get("fallback_rests"),
+            len(raised),
+            first_error,
+        )
+    except Exception:
+        return (None, None, None, None, None, None, None, None)
+
+
+def _run_subprocess(
+    pred_path: Path,
+    ref_path: Path,
+    metrics: list[str],
+    timeout: int,
+    *,
+    venv_python: Path | None = None,
+) -> dict:
+    """Run eval._score_one_piece in a subprocess and return the parsed JSON dict.
+
+    On success: returns dict with metric keys populated.
+    On failure (timeout, crash, bad JSON): returns dict with 'error' key set to
+    a short description string.
+    """
+    python = venv_python or _DEFAULT_VENV_PYTHON
+    cmd = [
+        str(python), "-m", "eval._score_one_piece",
+        "--pred", str(pred_path),
+        "--ref", str(ref_path),
+        "--metrics", ",".join(metrics),
+    ]
+    repo_root = Path(__file__).resolve().parents[1]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=str(repo_root),
+        )
+        if result.returncode != 0:
+            stderr_snippet = (result.stderr or "")[-500:].strip()
+            return {"error": f"subprocess exit {result.returncode}: {stderr_snippet}"}
+        # Last non-empty line of stdout should be the JSON payload
+        lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        if not lines:
+            return {"error": "subprocess produced no output"}
+        payload = json.loads(lines[-1])
+        return payload
+    except subprocess.TimeoutExpired:
+        return {"error": f"subprocess timeout after {timeout}s"}
+    except json.JSONDecodeError as e:
+        return {"error": f"JSON decode error: {e}"}
+    except Exception as e:
+        return {"error": f"{type(e).__name__}: {e}"}
+
+
+def score_piece_subprocess(
+    stem: str,
+    pred_path: Path,
+    ref_path: Path,
+    metrics: list[str],
+    *,
+    venv_python: Path | None = None,
+    cheap_timeout: int = CHEAP_TIMEOUT_SEC,
+    tedn_timeout: int = TEDN_TIMEOUT_SEC,
+) -> dict:
+    """Score one piece, splitting cheap and tedn metrics into separate subprocesses.
+
+    When *metrics* contains both tedn and at least one cheap metric
+    (onset_f1 / linearized_ser), two subprocess calls are made:
+
+      1. Cheap pair (onset_f1 + linearized_ser present in *metrics*) with
+         *cheap_timeout* (default 60 s).
+      2. Tedn-only with *tedn_timeout* (default 300 s).
+
+    The results are merged into a single dict.  Partial failures are surfaced in
+    the 'error' key with a prefix indicating which group failed, e.g.
+    "tedn: subprocess timeout after 300s".  If both groups fail the reasons are
+    joined with " | ".
+
+    When *metrics* is a strict subset of one group (e.g. only tedn, or only
+    onset_f1), a single subprocess call is used with the appropriate timeout.
+
+    Returns a dict with metric-value keys plus optionally an 'error' key
+    describing any failure(s).
+    """
+    cheap_requested = [m for m in metrics if m in CHEAP_METRICS]
+    tedn_requested = [m for m in metrics if m == "tedn"]
+
+    # Decide whether to split into two calls
+    need_split = bool(cheap_requested) and bool(tedn_requested)
+
+    if not need_split:
+        # Single call -- use appropriate timeout
+        timeout = cheap_timeout if not tedn_requested else tedn_timeout
+        return _run_subprocess(pred_path, ref_path, metrics, timeout, venv_python=venv_python)
+
+    # --- Split path: two subprocess calls ---
+    combined: dict = {}
+    failure_parts: list[str] = []
+
+    # 1. Cheap pair
+    cheap_result = _run_subprocess(
+        pred_path, ref_path, cheap_requested, cheap_timeout, venv_python=venv_python
+    )
+    if "error" in cheap_result:
+        failure_parts.append(f"cheap-pair: {cheap_result['error']}")
+    else:
+        combined.update({k: v for k, v in cheap_result.items() if k != "error"})
+
+    # 2. Tedn-only
+    tedn_result = _run_subprocess(
+        pred_path, ref_path, tedn_requested, tedn_timeout, venv_python=venv_python
+    )
+    if "error" in tedn_result:
+        failure_parts.append(f"tedn: {tedn_result['error']}")
+    else:
+        combined.update({k: v for k, v in tedn_result.items() if k != "error"})
+
+    if failure_parts:
+        combined["error"] = " | ".join(failure_parts)
+
+    return combined

--- a/eval/run_lieder_eval.py
+++ b/eval/run_lieder_eval.py
@@ -1,5 +1,17 @@
 """Run a trained Clarity-OMR-Train-RADIO checkpoint through the Lieder eval split.
 
+**Inference-only pass.** This script does NOT compute metrics. Its only job is
+to run the RADIO/YOLO inference pipeline for each piece and write the predicted
+MusicXML (plus Stage-D diagnostics sidecar) to disk. Metric scoring is handled
+by the separate eval/score_lieder_eval.py, which subprocess-isolates per-piece
+metric computation so music21/zss memory is fully reclaimed after each piece.
+
+This two-pass design was adopted after a 20-piece lieder run hit 43 GB committed
+memory at piece 6/20 and had to be killed before pagefile exhaustion. Same root
+cause as the demo eval OOM (PR #26): in-process metric scoring accumulates
+music21/zss state across pieces. See eval/score_lieder_eval.py and PR #26 for
+the motivation and memory profile.
+
 Wraps src.pdf_to_musicxml (full Stage A YOLO + Stage B RADIO/DaViT + MusicXML
 export pipeline already vendored in this repo). Uses sibling Clarity-OMR's
 shipped YOLO weights for Stage A; loads our trained Stage B checkpoint via
@@ -17,12 +29,15 @@ Usage:
         --checkpoint checkpoints/mvp_radio_stage2/stage2-radio-mvp_step_0000150.pt \\
         --config configs/train_stage2_radio_mvp.yaml \\
         --name mvp \\
-        --limit 3   # optional smoke cap
+        --max-pieces 20   # optional smoke cap
+
+Then score:
+    venv\\Scripts\\python -m eval.score_lieder_eval \\
+        --predictions-dir eval/results/lieder_mvp \\
+        --reference-dir data/openscore_lieder/scores \\
+        --name mvp
 """
 import argparse
-import csv
-import json
-import statistics
 import sys
 from pathlib import Path
 
@@ -31,9 +46,6 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_REPO_ROOT))
 
 from eval.lieder_split import get_eval_pieces, split_hash
-from eval.playback import playback_f
-from eval.tedn import compute_tedn
-from eval.linearized_musicxml import compute_linearized_ser
 
 # Path to our venv's Python — used to invoke src.pdf_to_musicxml as a subprocess
 VENV_PYTHON = Path(__file__).resolve().parents[1] / "venv" / "Scripts" / "python.exe"
@@ -43,12 +55,8 @@ VENV_PYTHON = Path(__file__).resolve().parents[1] / "venv" / "Scripts" / "python
 # in this repo, so reuse it.
 STAGE_A_YOLO = Path.home() / "Clarity-OMR" / "info" / "yolo.pt"
 
-# Inference uses our own src.pdf_to_musicxml — our fork already has the full
-# pipeline (Stage A wrapper + cli helpers + decoding/* + pipeline/*), and our
-# src.eval.evaluate_stage_b_checkpoint detects DoRA-wrapped checkpoints and
-# applies _prepare_model_for_dora before load_state_dict, so our trained
-# checkpoint loads via --stage-b-checkpoint with no further conversion.
-PDF_TO_MUSICXML_TIMEOUT_SEC = 1800  # 30-min cap per piece
+# Inference timeout: 30 minutes per piece
+PDF_TO_MUSICXML_TIMEOUT_SEC = 1800
 
 
 def run_inference(
@@ -63,11 +71,16 @@ def run_inference(
 ) -> None:
     """Run our trained Stage B + sibling YOLO Stage A on `pdf`, write MusicXML to `out`.
 
+    Spawns src.pdf_to_musicxml in a *child process* so that the RADIO encoder,
+    checkpoint weights, and all torch tensors are released when the child exits.
+    This is the key isolation that prevents OOM across pieces.
+
     Defaults are tuned for MVP-quality models: greedy decode (beam=1) with a 256-step
     cap is ~10x faster than the standard beam=5 / max=512 used at full-Stage-3 quality.
     For real eval against a Stage 3 checkpoint, override via --beam-width / --max-decode-steps.
     """
     import subprocess
+
     if not STAGE_A_YOLO.exists():
         raise SystemExit(
             f"FATAL: Stage A YOLO weights not found at {STAGE_A_YOLO}. "
@@ -97,7 +110,11 @@ def run_inference(
 
 
 def main() -> None:
-    p = argparse.ArgumentParser()
+    p = argparse.ArgumentParser(
+        description="Inference-only pass: run Stage B checkpoint on the Lieder eval split "
+                    "and write predicted MusicXML + Stage-D diagnostics sidecars to disk. "
+                    "Run eval/score_lieder_eval.py afterwards to compute metrics."
+    )
     p.add_argument(
         "--checkpoint", type=Path, required=True,
         help="path to trained Stage B .pt checkpoint",
@@ -108,7 +125,7 @@ def main() -> None:
     )
     p.add_argument(
         "--name", required=True,
-        help="run name (used for output dir + CSV filename)",
+        help="run name (used for output dir: eval/results/lieder_<name>/)",
     )
     p.add_argument(
         "--beam-width", type=int, default=1,
@@ -119,8 +136,9 @@ def main() -> None:
         help="Stage-B max decode steps per staff (default 256; full quality is 512)",
     )
     p.add_argument(
-        "--limit", type=int, default=None,
-        help="Optional cap on number of pieces (for smoke runs)",
+        "--max-pieces", type=int, default=None,
+        help="Truncate the eval split to the first N pieces (for smoke runs or staged rollout). "
+             "Default None runs all pieces in the split.",
     )
     args = p.parse_args()
 
@@ -135,9 +153,10 @@ def main() -> None:
         "The eval split has changed - do not proceed."
     )
     print("Split hash verified: 8e7d206f53ae3976")
-    print(f"Run name: {args.name}")
+    print(f"Run name:   {args.name}")
     print(f"Checkpoint: {args.checkpoint}")
-    print(f"Config: {args.config}")
+    print(f"Config:     {args.config}")
+    print(f"Mode:       INFERENCE ONLY (no metric scoring)")
     print()
 
     repo_root = Path(__file__).resolve().parents[1]
@@ -147,52 +166,27 @@ def main() -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     eval_pieces = get_eval_pieces()
-    if args.limit is not None:
-        eval_pieces = eval_pieces[: args.limit]
-        print(f"--limit {args.limit}: running on first {len(eval_pieces)} pieces only")
+    if args.max_pieces is not None:
+        full_count = len(eval_pieces)
+        eval_pieces = eval_pieces[: args.max_pieces]
+        print(f"Truncating to first {args.max_pieces} pieces of {full_count}")
     n_total = len(eval_pieces)
-    # Each row: (piece, onset_f1, tedn, lin_ser,
-    #            stage_d_skipped_notes, stage_d_skipped_chords,
-    #            stage_d_missing_durations, stage_d_malformed_spans,
-    #            stage_d_unknown_tokens, stage_d_fallback_rests,
-    #            stage_d_raised_count, stage_d_first_error)
-    rows: list[tuple] = []
-
-    def _read_stage_d_diag(pred_path: Path) -> tuple:
-        """Return the 8 Stage-D diagnostic CSV values for *pred_path*.
-
-        Looks for <pred_path>.diagnostics.json alongside the MusicXML output.
-        Returns a tuple of 8 values (all None if the sidecar is absent or unreadable).
-        """
-        diag_path = pred_path.with_suffix(pred_path.suffix + ".diagnostics.json")
-        try:
-            raw = json.loads(diag_path.read_text(encoding="utf-8"))
-            raised = raw.get("raised_during_part_append", [])
-            first_error = raised[0].get("error_message", "") if raised else ""
-            return (
-                raw.get("skipped_notes"),
-                raw.get("skipped_chords"),
-                raw.get("missing_durations"),
-                raw.get("malformed_spans"),
-                raw.get("unknown_tokens"),
-                raw.get("fallback_rests"),
-                len(raised),
-                first_error,
-            )
-        except Exception:
-            return (None, None, None, None, None, None, None, None)
+    n_ok = 0
+    n_skip = 0
+    n_fail = 0
 
     for i, piece in enumerate(eval_pieces, 1):
-        # piece from get_eval_pieces() is relative to cwd; resolve to absolute
-        piece_abs = (repo_root / piece).resolve()
         pdf = pdf_dir / f"{piece.stem}.pdf"
+
         if not pdf.exists():
-            print(f"[{i}/{n_total}] SKIP {piece.stem}: no rendered PDF")
-            rows.append((piece.stem, None, None, None) + (None,) * 8)
+            print(f"[{i}/{n_total}] SKIP {piece.stem}: no rendered PDF at {pdf}")
+            n_skip += 1
             continue
+
+        pred = out_dir / f"{piece.stem}.musicxml"
+        work_dir = work_base / piece.stem
+
         try:
-            pred = out_dir / f"{piece.stem}.musicxml"
-            work_dir = work_base / piece.stem
             if not pred.exists():
                 print(f"[{i}/{n_total}] inference {piece.stem} ...")
                 run_inference(
@@ -200,59 +194,30 @@ def main() -> None:
                     beam_width=args.beam_width,
                     max_decode_steps=args.max_decode_steps,
                 )
+                if pred.exists():
+                    print(f"[{i}/{n_total}] done     {piece.stem}  ({pred.stat().st_size // 1024} KB)")
+                else:
+                    print(f"[{i}/{n_total}] WARN     {piece.stem}: inference completed but output not found")
             else:
-                print(f"[{i}/{n_total}] cached  {piece.stem}")
-            # Read Stage D diagnostics sidecar (written by src.pdf_to_musicxml).
-            stage_d_cols = _read_stage_d_diag(pred)
-            f1 = playback_f(pred=pred, gt=piece_abs)["f"]
-            try:
-                tedn = compute_tedn(piece_abs, pred)
-            except Exception as te:
-                print(f"[{i}/{n_total}]   tedn WARN {piece.stem}: {te}")
-                tedn = None
-            try:
-                lin_ser = compute_linearized_ser(piece_abs, pred)
-            except Exception as le:
-                print(f"[{i}/{n_total}]   lin_ser WARN {piece.stem}: {le}")
-                lin_ser = None
-            rows.append((piece.stem, f1, tedn, lin_ser) + stage_d_cols)
-            tedn_str = f"{tedn:.4f}" if tedn is not None else "N/A"
-            lin_str = f"{lin_ser:.4f}" if lin_ser is not None else "N/A"
-            print(f"[{i}/{n_total}] {piece.stem}: onset_f1={f1:.4f}  tedn={tedn_str}  lin_ser={lin_str}")
+                print(f"[{i}/{n_total}] cached   {piece.stem}  ({pred.stat().st_size // 1024} KB)")
+            n_ok += 1
         except Exception as e:
             print(f"[{i}/{n_total}] FAIL {piece.stem}: {type(e).__name__}: {e}")
-            rows.append((piece.stem, None, None, None) + (None,) * 8)
+            n_fail += 1
 
-    csv_path = (repo_root / "eval/results" / f"lieder_{args.name}.csv").resolve()
-    csv_path.parent.mkdir(parents=True, exist_ok=True)
-    with csv_path.open("w", newline="") as fh:
-        w = csv.writer(fh)
-        w.writerow([
-            "piece", "onset_f1", "tedn", "linearized_ser",
-            "stage_d_skipped_notes", "stage_d_skipped_chords",
-            "stage_d_missing_durations", "stage_d_malformed_spans",
-            "stage_d_unknown_tokens", "stage_d_fallback_rests",
-            "stage_d_raised_count", "stage_d_first_error",
-        ])
-        w.writerows(rows)
-    print(f"\nResults written to {csv_path}")
-
-    valid = [row[1] for row in rows if row[1] is not None]
-    failed_count = sum(1 for row in rows if row[1] is None)
-    if not valid:
-        print(f"\nNo pieces scored successfully ({failed_count}/{n_total} failed/skipped).")
-        return
-
-    mean_f1 = statistics.mean(valid)
-    med_f1 = statistics.median(valid)
-    min_f1 = min(valid)
-    max_f1 = max(valid)
-    print(f"\n=== Lieder Eval Results ({args.name}) ===")
-    print(f"Pieces evaluated: {len(valid)} / {n_total} (failed/skipped: {failed_count})")
-    print(f"Mean onset-F1:   {mean_f1:.4f}")
-    print(f"Median onset-F1: {med_f1:.4f}")
-    print(f"Min onset-F1:    {min_f1:.4f}")
-    print(f"Max onset-F1:    {max_f1:.4f}")
+    print()
+    print(f"=== Inference complete ===")
+    print(f"  OK:      {n_ok}/{n_total}")
+    print(f"  Skipped: {n_skip}/{n_total}")
+    print(f"  Failed:  {n_fail}/{n_total}")
+    print()
+    print(f"Predicted XMLs written to: {out_dir}")
+    print()
+    print("Next step — run metric scoring:")
+    print(f"  venv\\Scripts\\python -m eval.score_lieder_eval \\")
+    print(f"      --predictions-dir {out_dir} \\")
+    print(f"      --reference-dir {(repo_root / 'data/openscore_lieder/scores').resolve()} \\")
+    print(f"      --name {args.name}")
 
 
 if __name__ == "__main__":

--- a/eval/score_lieder_eval.py
+++ b/eval/score_lieder_eval.py
@@ -1,33 +1,40 @@
-"""Score per-piece metric results for the 4 canonical demo pieces.
+"""Score per-piece metric results for a Lieder eval inference run.
 
 Two-pass design:
-- Pass 1 (run_clarity_demo_eval.py): inference only — writes predicted MusicXML
-  and optional diagnostics sidecars to --predictions-dir.
+- Pass 1 (run_lieder_eval.py): inference only — writes predicted MusicXML
+  and Stage-D diagnostics sidecars to --predictions-dir.
 - Pass 2 (this script): scoring only — subprocess-isolates per-piece metric
   computation so each piece's music21/zss memory is fully reclaimed after the
   subprocess exits. The parent process stays small throughout.
 
+This design was adopted after a 20-piece lieder run hit 43 GB committed memory
+at piece 6/20 and had to be killed before pagefile exhaustion. The subprocess
+isolation reclaims all music21/zss state on subprocess exit; PR #26's demo eval
+ran 4/4 pieces with the parent staying ~5 GB and per-piece subprocess peaks
+~2.5 GB.
+
 Each piece is scored in up to TWO fresh child processes (eval._score_one_piece):
 
   1. Cheap pair (onset_f1 + linearized_ser): 60 s timeout. These metrics finish
-     in <2 s even for large scores (<=43 MB data) and are always attempted first.
-  2. Tedn-only: 300 s timeout.  May time out for very large scores (Clair de
-     Lune peaks >37 GB); when it does the cheap metrics are still recovered.
+     in <2 s even for large scores and are always attempted first.
+  2. Tedn-only: 300 s timeout. May time out for very large scores; when it does
+     the cheap metrics are still recovered.
 
-If only cheap metrics were requested (or only tedn), a single subprocess is
-used.  The split only activates when the requested set includes both tedn and
-at least one cheap metric.
+Shared scoring infrastructure lives in eval._scoring_utils (also used by
+eval.score_demo_eval).
 
-Shared scoring infrastructure (subprocess dispatch, sidecar reading, CSV schema)
-lives in eval._scoring_utils and is also used by eval.score_lieder_eval.
+Piece discovery: auto-discovers all .musicxml files in --predictions-dir, so
+there is no hard-coded stem list. Reference MXLs are looked up in --reference-dir
+by stem (e.g. <stem>.mxl) — point this at the openscore_lieder scores directory
+(data/openscore_lieder/scores or the eval_mxl mirror).
 
 Usage:
-    venv-cu132\\Scripts\\python -m eval.score_demo_eval \\
-        --predictions-dir eval/results/clarity_demo_stage2_best \\
-        --reference-dir data/clarity_demo/mxl \\
-        --name stage2_best
+    venv\\Scripts\\python -m eval.score_lieder_eval \\
+        --predictions-dir eval/results/lieder_mvp \\
+        --reference-dir data/openscore_lieder/scores \\
+        --name mvp
 
-Output: eval/results/clarity_demo_<name>.csv
+Output: eval/results/lieder_<name>.csv
 """
 import argparse
 import csv
@@ -47,42 +54,63 @@ from eval._scoring_utils import (
     score_piece_subprocess,
 )
 
-# Path to our venv's Python -- same one that ran inference
-VENV_PYTHON = Path(__file__).resolve().parents[1] / "venv-cu132" / "Scripts" / "python.exe"
+# Path to our venv's Python — same one that ran lieder inference
+VENV_PYTHON = Path(__file__).resolve().parents[1] / "venv" / "Scripts" / "python.exe"
 
-# Backward-compat alias
-SCORE_TIMEOUT_SEC = TEDN_TIMEOUT_SEC
 
-# Canonical demo stems -- must match run_clarity_demo_eval.py
-DEMO_STEMS = [
-    "clair-de-lune-debussy",
-    "fugue-no-2-bwv-847-in-c-minor",
-    "gnossienne-no-1",
-    "prelude-in-d-flat-major-op31-no1-scriabin",
-]
+def _discover_predictions(predictions_dir: Path) -> list[Path]:
+    """Return sorted list of .musicxml prediction files in *predictions_dir*."""
+    return sorted(predictions_dir.glob("*.musicxml"))
+
+
+def _find_reference(stem: str, reference_dir: Path) -> Path | None:
+    """Locate the ground-truth MXL for *stem* under *reference_dir*.
+
+    Searches recursively — the openscore_lieder corpus is nested under
+    <Composer>/<Opus>/<Song>/<id>.mxl, so a flat directory is not assumed.
+    Returns the first match, or None if not found.
+    """
+    # Try flat first (e.g. a pre-flattened eval_mxl mirror)
+    flat = reference_dir / f"{stem}.mxl"
+    if flat.exists():
+        return flat
+    # Recursive search for the first match
+    matches = list(reference_dir.rglob(f"{stem}.mxl"))
+    if matches:
+        return matches[0]
+    return None
 
 
 def main() -> None:
     p = argparse.ArgumentParser(
-        description="Score predicted MusicXMLs against reference MXLs, "
-                    "subprocess-isolating per-piece metric computation."
+        description="Score predicted MusicXMLs from a Lieder eval inference run against "
+                    "reference MXLs, subprocess-isolating per-piece metric computation."
     )
     p.add_argument(
         "--predictions-dir", type=Path, required=True,
-        help="Directory containing predicted .musicxml files (output of run_clarity_demo_eval.py)",
+        help="Directory containing predicted .musicxml files (output of run_lieder_eval.py). "
+             "All .musicxml files in this directory are scored.",
     )
     p.add_argument(
         "--reference-dir", type=Path, required=True,
-        help="Directory containing reference .mxl files",
+        help="Directory containing reference .mxl files. Can be the full openscore_lieder/scores "
+             "tree (recursive search used) or a flat mirror. "
+             "Example: data/openscore_lieder/scores",
     )
     p.add_argument(
         "--name", required=True,
-        help="Run name (used for output CSV filename: eval/results/clarity_demo_<name>.csv)",
+        help="Run name (used for output CSV filename: eval/results/lieder_<name>.csv). "
+             "Should match the name used with run_lieder_eval.py.",
     )
     p.add_argument(
         "--metrics",
         default="tedn,linearized_ser,onset_f1",
         help="Comma-separated list of metrics to compute (default: tedn,linearized_ser,onset_f1)",
+    )
+    p.add_argument(
+        "--max-pieces", type=int, default=None,
+        help="Score only the first N predictions (for validating a partial inference run). "
+             "Default None scores all discovered predictions.",
     )
     args = p.parse_args()
 
@@ -97,6 +125,17 @@ def main() -> None:
     if unknown:
         raise SystemExit(f"FATAL: unknown metrics: {unknown}. Valid: {valid_metrics}")
 
+    preds = _discover_predictions(args.predictions_dir)
+    if not preds:
+        raise SystemExit(
+            f"FATAL: no .musicxml files found in {args.predictions_dir}. "
+            "Run eval/run_lieder_eval.py first."
+        )
+    if args.max_pieces is not None:
+        full_count = len(preds)
+        preds = preds[: args.max_pieces]
+        print(f"Truncating to first {args.max_pieces} predictions of {full_count}")
+
     cheap_requested = [m for m in metrics if m in CHEAP_METRICS]
     tedn_requested = [m for m in metrics if m == "tedn"]
     splitting = bool(cheap_requested) and bool(tedn_requested)
@@ -105,7 +144,7 @@ def main() -> None:
     print(f"Predictions dir: {args.predictions_dir}")
     print(f"Reference dir:   {args.reference_dir}")
     print(f"Metrics:         {metrics}")
-    print(f"Pieces:          {len(DEMO_STEMS)}")
+    print(f"Pieces:          {len(preds)}")
     if splitting:
         print(f"Scoring mode:    split (cheap={cheap_requested} @{CHEAP_TIMEOUT_SEC}s,"
               f" tedn @{TEDN_TIMEOUT_SEC}s)")
@@ -115,19 +154,15 @@ def main() -> None:
     print()
 
     repo_root = Path(__file__).resolve().parents[1]
-    n_total = len(DEMO_STEMS)
+    n_total = len(preds)
     rows: list[tuple] = []
 
-    for i, stem in enumerate(DEMO_STEMS, 1):
-        pred = args.predictions_dir / f"{stem}.musicxml"
-        ref = args.reference_dir / f"{stem}.mxl"
+    for i, pred in enumerate(preds, 1):
+        stem = pred.stem  # e.g. "bach-bwv123-liebster-gott"
+        ref = _find_reference(stem, args.reference_dir)
 
-        if not pred.exists():
-            print(f"[{i}/{n_total}] SKIP {stem}: predicted XML not found at {pred}")
-            rows.append((stem, None, None, None) + (None,) * 8 + ("predicted_xml_missing",))
-            continue
-        if not ref.exists():
-            print(f"[{i}/{n_total}] SKIP {stem}: reference MXL not found at {ref}")
+        if not ref:
+            print(f"[{i}/{n_total}] SKIP {stem}: reference MXL not found under {args.reference_dir}")
             rows.append((stem, None, None, None) + (None,) * 8 + ("reference_mxl_missing",))
             continue
 
@@ -137,7 +172,7 @@ def main() -> None:
         stage_d_cols = _read_stage_d_diag(pred)
 
         # Metric scoring runs in subprocess(es) -- OS reclaims all music21/zss memory
-        # when the child exits, preventing the 86 GB committed-memory OOM seen in v1.
+        # when the child exits, preventing the 43 GB OOM seen in the old in-process design.
         # cheap metrics and tedn are split into separate calls so a tedn timeout
         # does not discard already-computed onset_f1 / linearized_ser values.
         payload = score_piece_subprocess(
@@ -155,13 +190,12 @@ def main() -> None:
         lin_str = f"{lin_ser:.4f}" if lin_ser is not None else "N/A"
         f1_str = f"{f1:.4f}" if f1 is not None else "N/A"
         if failure_reason:
-            # Partial success: some metrics may still be populated
             print(f"[{i}/{n_total}] PARTIAL/FAIL {stem}: {failure_reason}")
             print(f"             onset_f1={f1_str}  tedn={tedn_str}  lin_ser={lin_str}")
         else:
             print(f"[{i}/{n_total}] {stem}: onset_f1={f1_str}  tedn={tedn_str}  lin_ser={lin_str}")
 
-    csv_path = (repo_root / "eval/results" / f"clarity_demo_{args.name}.csv").resolve()
+    csv_path = (repo_root / "eval/results" / f"lieder_{args.name}.csv").resolve()
     csv_path.parent.mkdir(parents=True, exist_ok=True)
     with csv_path.open("w", newline="") as fh:
         w = csv.writer(fh)
@@ -179,7 +213,7 @@ def main() -> None:
     med_f1 = statistics.median(valid)
     min_f1 = min(valid)
     max_f1 = max(valid)
-    print(f"\n=== Clarity Demo Scoring Results ({args.name}) ===")
+    print(f"\n=== Lieder Scoring Results ({args.name}) ===")
     print(f"Pieces evaluated: {len(valid)} / {n_total} (failed/skipped: {failed_count})")
     print(f"Mean onset-F1:   {mean_f1:.4f}")
     print(f"Median onset-F1: {med_f1:.4f}")

--- a/eval/tests/test_score_lieder_eval.py
+++ b/eval/tests/test_score_lieder_eval.py
@@ -1,0 +1,62 @@
+"""Smoke tests for eval.score_lieder_eval.
+
+Verifies module imports and CLI help renders without error.
+Does NOT run actual metric scoring (requires torch + music21 not available on
+the Linux CI box).
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Subprocess env with repo root on PYTHONPATH so `eval.*` modules resolve
+_SUBPROCESS_ENV = {**os.environ, "PYTHONPATH": str(_REPO_ROOT)}
+
+
+def test_imports():
+    """score_lieder_eval and its _scoring_utils dependency import cleanly."""
+    import importlib
+    import sys
+
+    # Ensure repo root is on path
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+
+    mod = importlib.import_module("eval.score_lieder_eval")
+    assert hasattr(mod, "main")
+    assert hasattr(mod, "_discover_predictions")
+    assert hasattr(mod, "_find_reference")
+
+
+def test_help_renders(tmp_path):
+    """--help exits 0 and produces non-empty output."""
+    result = subprocess.run(
+        [sys.executable, "-m", "eval.score_lieder_eval", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO_ROOT),
+        env=_SUBPROCESS_ENV,
+    )
+    assert result.returncode == 0, f"--help failed:\n{result.stderr}"
+    assert "predictions-dir" in result.stdout
+    assert "reference-dir" in result.stdout
+    assert "max-pieces" in result.stdout
+
+
+def test_missing_predictions_dir_exits_nonzero():
+    """Passing a nonexistent --predictions-dir exits with a non-zero code."""
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "eval.score_lieder_eval",
+            "--predictions-dir", "/nonexistent/path/to/preds",
+            "--reference-dir", "/nonexistent/path/to/refs",
+            "--name", "smoke",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO_ROOT),
+        env=_SUBPROCESS_ENV,
+    )
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary

Refactor `eval/run_lieder_eval.py` to mirror PR #26's two-pass design:
- `eval/run_lieder_eval.py` — **inference only** (writes predicted MusicXML + Stage D sidecars per piece)
- `eval/score_lieder_eval.py` (new) — **scoring only** with subprocess-isolated per-piece metric computation (cheap pair @60s, tedn @300s)

Folds in PR #25's `--max-pieces` flag (now on the inference script) and the timeout work (now built into the scoring split, replacing the per-script flags).

Shared subprocess infrastructure extracted to `eval/_scoring_utils.py`, imported by both `score_demo_eval.py` and `score_lieder_eval.py` — one canonical pattern, no duplication.

## Motivation

Yesterday's truncated 20-piece lieder eval hit **43 GB committed memory** at piece 6/20 and had to be killed before pagefile exhaustion. Same root cause as the demo eval OOM (PR #26): in-process metric scoring accumulates music21/zss state across pieces. The 146-piece full corpus on Stage 2/3 won't fit in RAM with the old design.

The new design subprocess-isolates each piece's scoring, so memory is reclaimed by the OS on subprocess exit. PR #26's demo eval ran 4/4 pieces with parent staying ~5 GB and per-piece subprocess peaks ~2.5 GB.

## Changes

- `eval/_scoring_utils.py` (new) — shared scoring infrastructure: `score_piece_subprocess()`, `_run_subprocess()`, `_read_stage_d_diag()`, `CSV_HEADER`, timeout constants
- `eval/run_lieder_eval.py` — stripped to inference-only; added `--max-pieces`; dropped inline metric calls and threading timeout helpers
- `eval/score_lieder_eval.py` (new) — scoring pass; auto-discovers predictions by glob; recursive ref lookup (handles nested openscore corpus tree); `--max-pieces` flag
- `eval/score_demo_eval.py` — refactored to import from `_scoring_utils` (no behavior change)
- `eval/tests/test_score_lieder_eval.py` (new) — 3 smoke tests (import, --help, bad-dir exit)
- `eval/README.md` — updated for two-pass workflow for both demo and lieder

## Test plan

- [x] `--help` renders for both new entry points
- [x] Imports work on this Linux box (no torch needed for the parent script)
- [x] 3 smoke tests pass: `pytest eval/tests/test_score_lieder_eval.py`
- [ ] Stage 3 lieder eval (`--max-pieces 20` to start) using this PR's branch
- [ ] If memory holds: full 146-piece run
- [ ] Compare numbers to Stage 2 lieder partial (only 6 pieces fully scored before OOM yesterday)

## Closes

- Closes #25 — PR #25's flags + work folded into this refactor
- Addresses #27 (tedn scaling) at the architectural level — tedn timeouts are now contained per-piece without losing cheap metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)