### PR TITLE
chore(scripts): commit Stage 3 launcher used for production run

### DIFF
--- a/scripts/full_radio_stage3_inner.ps1
+++ b/scripts/full_radio_stage3_inner.ps1
@@ -3,7 +3,7 @@
 $ErrorActionPreference = "Stop"
 $repo = Join-Path $env:USERPROFILE "Clarity-OMR-Train-RADIO"
 Set-Location $repo
-$py = Join-Path $repo "venv\Scripts\python.exe"
+$py = Join-Path $repo "venv-cu132\Scripts\python.exe"
 $resume = "checkpoints\full_radio_stage2\stage2-radio-polyphonic_final.pt"
 $pyArgs = @(
     "-u", "src/train/train.py",
@@ -14,7 +14,11 @@ $pyArgs = @(
     "--checkpoint-dir", "checkpoints/full_radio_stage3",
     "--token-manifest", "src/data/manifests/token_manifest_full.jsonl,data/processed/synthetic/manifests/synthetic_token_manifest.jsonl",
     "--step-log", "logs/full_radio_stage3_steps.jsonl",
-    "--validation-batches", "16"
+    "--validation-batches", "16",
+    "--num-workers", "4",
+    "--prefetch-factor", "4",
+    "--torch-compile",
+    "--channels-last"
 )
 Remove-Item "logs/full_radio_stage3.log","logs/full_radio_stage3.err","logs/full_radio_stage3.pid","logs/full_radio_stage3_wrapper.log","logs/full_radio_stage3_steps.jsonl" -ErrorAction SilentlyContinue
 $proc = Start-Process -FilePath $py `


### PR DESCRIPTION
## Summary

Capture the cu132 + DataLoader configuration that was actually used to launch the Stage 3 training run on 2026-04-27. This launcher had been edited locally on the host but the change was never committed.

## Diff vs the prior tracked version

- Switch venv from cu128 (`venv/`) to cu132 (`venv-cu132/`).
- Add `--num-workers 4 --prefetch-factor 4` (also `train.py` defaults; kept explicit for documentation).
- Add `--torch-compile` and `--channels-last` (opt-ins from PRs #11 + #14). PR #30 flipped `--torch-compile` to default-on, so the explicit flag is now redundant but harmless.

## Test plan

This commit doesn't change Stage 3's behavior — it just preserves the exact launcher contents that produced the production checkpoint at `checkpoints/full_radio_stage3/stage3-radio-full-complexity_best.pt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)