### PR TITLE
chore: gitignore cleanup + promote 7 operational scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,11 +187,30 @@ eval/results/cache/
 !data/README.md
 !data/**/README.md
 
-# Training logs
-logs/*.log
-logs/*.jsonl
+# Training logs and operator helpers (keep on disk for reference, don't track)
+logs/*
+!logs/.gitkeep
 
 # Generated manifests and training summaries
 src/data/manifests/*.jsonl
 src/data/manifests/*.json
 src/train/curriculum_summary.json
+
+# Eval outputs (keep on disk for analysis, don't track per-run results)
+eval/results/*
+!eval/results/.gitkeep
+!eval/results/baseline_davit_lieder.csv
+!eval/results/lieder_mvp.csv
+!eval/results/baseline_pre_rebuild/
+eval/results/baseline_pre_rebuild/*
+!eval/results/baseline_pre_rebuild/measure_stage_a.py
+!eval/results/baseline_pre_rebuild/stage_a_recall.csv
+
+# Local-only top-level dirs (training runs, audit/bench outputs, scratch)
+audit/
+bench/
+runs/
+scratch/
+
+# Model weight files at repo root (use checkpoints/ instead)
+/*.pt

--- a/scripts/breakdown_audit.py
+++ b/scripts/breakdown_audit.py
@@ -1,0 +1,55 @@
+"""Re-run audit but capture per-file kind sets for breakdown analysis."""
+import json
+import sys
+from pathlib import Path
+from collections import Counter
+
+sys.path.insert(0, ".")
+from src.data.kern_validation import compare_via_music21
+
+GRANDSTAFF_ROOT = Path("data/grandstaff")
+krn_paths = sorted(GRANDSTAFF_ROOT.rglob("*.krn"))
+print(f"auditing {len(krn_paths):,} files", file=sys.stderr)
+
+per_file_kinds = []  # list of (path, frozenset of kinds)
+files_failed = 0
+for i, kp in enumerate(krn_paths):
+    try:
+        r = compare_via_music21(kp)
+        kinds = frozenset(d.kind for d in r.divergences)
+        per_file_kinds.append((str(kp), kinds))
+    except Exception:
+        files_failed += 1
+        per_file_kinds.append((str(kp), frozenset(["__failed_to_compare__"])))
+    if (i + 1) % 5000 == 0:
+        print(f"  {i+1}/{len(krn_paths)}", file=sys.stderr)
+
+# Breakdown
+total = len(per_file_kinds)
+passing = sum(1 for _, k in per_file_kinds if not k)
+print(f"\ntotal: {total:,}")
+print(f"passing: {passing:,} ({passing/total*100:.1f}%)")
+print(f"failed_to_compare: {files_failed:,}")
+
+# Group failing files by their kind-set
+failing = [(p, k) for p, k in per_file_kinds if k]
+combo_counts = Counter(k for _, k in failing)
+
+print(f"\nfailing files broken down by their unique combination of divergence kinds:")
+print(f"{'count':>8s}  {'pct':>6s}  kinds")
+for combo, count in combo_counts.most_common(20):
+    pct = count / total * 100
+    label = ", ".join(sorted(combo))
+    print(f"{count:>8,}  {pct:>5.2f}%  {label}")
+
+# Single-kind vs multi-kind
+single = sum(1 for _, k in failing if len(k) == 1)
+multi = sum(1 for _, k in failing if len(k) > 1)
+print(f"\nfailing files with single-kind divergence: {single:,}")
+print(f"failing files with multi-kind divergence:  {multi:,}")
+
+# Save per-file kinds for further analysis
+with open("audit/per_file_kinds_v5.json", "w") as f:
+    json.dump([{"path": p, "kinds": sorted(k)} for p, k in per_file_kinds if k],
+              f, indent=2)
+print(f"\nsaved per_file kinds to audit/per_file_kinds_v5.json")

--- a/scripts/build_full_manifest.cmd
+++ b/scripts/build_full_manifest.cmd
@@ -1,0 +1,24 @@
+@echo off
+setlocal
+cd /d "%USERPROFILE%\Clarity-OMR-Train-RADIO"
+call venv\Scripts\activate.bat
+echo === [%date% %time%] STAGE 1: src.data.index (full corpus) ===
+python -u -m src.data.index ^
+  --data-root data ^
+  --split-config configs/splits.yaml ^
+  --output-manifest src/data/manifests/canonical_manifest_full.jsonl ^
+  --output-summary src/data/manifests/canonical_summary_full.json
+if errorlevel 1 (
+  echo === [%date% %time%] STAGE 1 FAILED, aborting ===
+  exit /b 1
+)
+echo === [%date% %time%] STAGE 1 OK ===
+echo === [%date% %time%] STAGE 2: src.data.convert_tokens (primus + cameraprimus + grandstaff) ===
+python -u -m src.data.convert_tokens ^
+  --input-manifest src/data/manifests/canonical_manifest_full.jsonl ^
+  --output-manifest src/data/manifests/token_manifest_full.jsonl ^
+  --output-summary src/data/manifests/token_summary_full.json ^
+  --datasets primus,cameraprimus,grandstaff
+set rc=%errorlevel%
+echo === [%date% %time%] DONE exit=%rc% ===
+exit /b %rc%

--- a/scripts/launch_mvp.ps1
+++ b/scripts/launch_mvp.ps1
@@ -1,0 +1,36 @@
+$ErrorActionPreference = "Stop"
+$repo = Join-Path $env:USERPROFILE "Clarity-OMR-Train-RADIO"
+Set-Location $repo
+$py = Join-Path $repo "venv\Scripts\python.exe"
+$pyArgs = @(
+    "-u", "src/train/train.py",
+    "--stage-configs", "configs/train_stage2_radio_mvp.yaml",
+    "--mode", "execute",
+    "--checkpoint-dir", "checkpoints/mvp_radio_stage2",
+    "--token-manifest", "src/data/manifests/token_manifest_full.jsonl",
+    "--step-log", "logs/mvp_radio_stage2_steps.jsonl"
+)
+Remove-Item "logs/mvp_radio_stage2.log","logs/mvp_radio_stage2.err","logs/mvp_radio_stage2.pid" -ErrorAction SilentlyContinue
+$proc = Start-Process -FilePath $py `
+    -ArgumentList $pyArgs `
+    -WorkingDirectory $repo `
+    -RedirectStandardOutput "logs/mvp_radio_stage2.log" `
+    -RedirectStandardError  "logs/mvp_radio_stage2.err" `
+    -WindowStyle Hidden `
+    -PassThru
+$proc.Id | Out-File -FilePath "logs/mvp_radio_stage2.pid" -Encoding ASCII -NoNewline
+Write-Output ("Started PID: " + $proc.Id + " at " + $proc.StartTime)
+Start-Sleep -Seconds 35
+$running = Get-Process -Id $proc.Id -ErrorAction SilentlyContinue
+if ($running) {
+    Write-Output ("ALIVE @35s: PID=" + $proc.Id + " CPU=" + [math]::Round($running.CPU,1) + "s WS=" + [math]::Round($running.WorkingSet64/1MB,0) + "MB")
+} else {
+    Write-Output ("DIED <35s: PID=" + $proc.Id + " ExitCode=" + $proc.ExitCode)
+}
+Write-Output "--- log size (out/err) ---"
+$o = Get-Item logs/mvp_radio_stage2.log -ErrorAction SilentlyContinue; if ($o) { Write-Output ("out " + $o.Length) }
+$e = Get-Item logs/mvp_radio_stage2.err -ErrorAction SilentlyContinue; if ($e) { Write-Output ("err " + $e.Length) }
+Write-Output "--- log tail ---"
+if (Test-Path logs/mvp_radio_stage2.log) { Get-Content logs/mvp_radio_stage2.log -Tail 10 }
+Write-Output "--- err tail ---"
+if (Test-Path logs/mvp_radio_stage2.err) { Get-Content logs/mvp_radio_stage2.err -Tail 10 }

--- a/scripts/lieder_eval_stage3_inner.ps1
+++ b/scripts/lieder_eval_stage3_inner.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = "Stop"
+$repo = Join-Path $env:USERPROFILE "Clarity-OMR-Train-RADIO"
+Set-Location $repo
+$py = Join-Path $repo "venv-cu132\Scripts\python.exe"
+$pyArgs = @(
+    "-u", "-m", "eval.run_lieder_eval",
+    "--checkpoint", "checkpoints/full_radio_stage3/stage3-radio-full-complexity_best.pt",
+    "--config", "configs/train_stage3_radio.yaml",
+    "--name", "stage3_best_max20",
+    "--max-pieces", "20"
+)
+Remove-Item "logs/lieder_eval_stage3.log","logs/lieder_eval_stage3.err","logs/lieder_eval_stage3.pid","logs/lieder_eval_stage3_wrapper.log" -ErrorAction SilentlyContinue
+$proc = Start-Process -FilePath $py -ArgumentList $pyArgs -WorkingDirectory $repo -RedirectStandardOutput "logs/lieder_eval_stage3.log" -RedirectStandardError "logs/lieder_eval_stage3.err" -NoNewWindow -PassThru
+$proc.Id | Out-File -FilePath "logs/lieder_eval_stage3.pid" -Encoding ASCII -NoNewline
+"Wrapper started python PID $($proc.Id) at $(Get-Date -Format o)" | Out-File -FilePath "logs/lieder_eval_stage3_wrapper.log" -Append
+$proc.WaitForExit()
+"Wrapper exit: python PID $($proc.Id) ExitCode=$($proc.ExitCode) at $(Get-Date -Format o)" | Out-File -FilePath "logs/lieder_eval_stage3_wrapper.log" -Append

--- a/scripts/lieder_eval_stage3_launch.ps1
+++ b/scripts/lieder_eval_stage3_launch.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = "Stop"
+$repo = Join-Path $env:USERPROFILE "Clarity-OMR-Train-RADIO"
+$inner = Join-Path $repo "scripts\lieder_eval_stage3_inner.ps1"
+$cmd = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File `"$inner`""
+$result = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{CommandLine=$cmd}
+Write-Output ("ReturnValue=" + $result.ReturnValue + " WrapperPID=" + $result.ProcessId)
+Start-Sleep -Seconds 15
+$pidFile = Join-Path $repo "logs\lieder_eval_stage3.pid"
+if (Test-Path $pidFile) {
+    $pyPid = [int](Get-Content $pidFile)
+    $p = Get-Process -Id $pyPid -ErrorAction SilentlyContinue
+    if ($p) { Write-Output ("ALIVE PythonPID=" + $pyPid + " StartTime=" + $p.StartTime) }
+    else { Write-Output ("DIED PythonPID=" + $pyPid) }
+}

--- a/scripts/lieder_full_inner.ps1
+++ b/scripts/lieder_full_inner.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = "Stop"
+$repo = Join-Path $env:USERPROFILE "Clarity-OMR-Train-RADIO"
+Set-Location $repo
+$py = Join-Path $repo "venv-cu132\Scripts\python.exe"
+$pyArgs = @(
+    "-u", "-m", "eval.run_lieder_eval",
+    "--checkpoint", "checkpoints/full_radio_stage3/stage3-radio-full-complexity_best.pt",
+    "--config", "configs/train_stage3_radio.yaml",
+    "--name", "stage3_best_full"
+)
+Remove-Item "logs/lieder_eval_stage3_full.log","logs/lieder_eval_stage3_full.err","logs/lieder_eval_stage3_full.pid","logs/lieder_eval_stage3_full_wrapper.log" -ErrorAction SilentlyContinue
+$proc = Start-Process -FilePath $py -ArgumentList $pyArgs -WorkingDirectory $repo -RedirectStandardOutput "logs/lieder_eval_stage3_full.log" -RedirectStandardError "logs/lieder_eval_stage3_full.err" -NoNewWindow -PassThru
+$proc.Id | Out-File -FilePath "logs/lieder_eval_stage3_full.pid" -Encoding ASCII -NoNewline
+"Wrapper started python PID $($proc.Id) at $(Get-Date -Format o)" | Out-File -FilePath "logs/lieder_eval_stage3_full_wrapper.log" -Append
+$proc.WaitForExit()
+"Wrapper exit: python PID $($proc.Id) ExitCode=$($proc.ExitCode) at $(Get-Date -Format o)" | Out-File -FilePath "logs/lieder_eval_stage3_full_wrapper.log" -Append

--- a/scripts/scan_tuplets.py
+++ b/scripts/scan_tuplets.py
@@ -1,0 +1,44 @@
+"""Scan all .krn files for unusual tuplet ratios appearing in music21's parse."""
+import sys
+from pathlib import Path
+from collections import Counter
+
+sys.path.insert(0, ".")
+import music21
+
+GRANDSTAFF_ROOT = Path("data/grandstaff")
+krn_paths = sorted(GRANDSTAFF_ROOT.rglob("*.krn"))
+print(f"scanning {len(krn_paths):,} files for tuplet ratios", file=sys.stderr)
+
+ratio_counts = Counter()
+files_with_unusual = set()
+
+for i, kp in enumerate(krn_paths):
+    try:
+        s = music21.converter.parse(str(kp), format="humdrum")
+        for elem in s.recurse().notesAndRests:
+            tuplets = list(getattr(elem.duration, "tuplets", []) or [])
+            if not tuplets:
+                continue
+            t = tuplets[0]
+            actual = int(getattr(t, "numberNotesActual", 0) or 0)
+            normal = int(getattr(t, "numberNotesNormal", 0) or 0)
+            if actual == 0 or normal == 0:
+                continue
+            ratio_counts[(actual, normal)] += 1
+            # Mark "unusual" = anything other than 3:2, 5:4, 6:4, 7:4
+            if (actual, normal) not in {(3, 2), (5, 4), (6, 4), (7, 4)}:
+                files_with_unusual.add(str(kp))
+    except Exception:
+        pass
+    if (i + 1) % 5000 == 0:
+        print(f"  {i+1}/{len(krn_paths)}", file=sys.stderr)
+
+print()
+print(f"--- Tuplet ratio distribution across corpus ---")
+for (a, n), count in sorted(ratio_counts.items(), key=lambda x: -x[1]):
+    label = f"{a}:{n}"
+    print(f"  {label:>8s}  {count:>10,} occurrences")
+
+print()
+print(f"files with at least one 'unusual' (non-3:2/5:4/6:4/7:4) tuplet: {len(files_with_unusual):,}")


### PR DESCRIPTION
## Summary

Two small, independent post-merge cleanups that surfaced after PR #41 landed:

1. **`.gitignore` extension** — close out ~200 untracked entries that were cluttering `git status` after the Stage 3 work:
   - `logs/*` (was just `logs/*.log` + `logs/*.jsonl`) — directory is now full of ad-hoc PowerShell helpers, `.err`/`.pid` artifacts, sample renders. Keeps `logs/.gitkeep` tracked.
   - `eval/results/*` with explicit negations for the 4 currently-tracked artifacts (`baseline_davit_lieder.csv`, `lieder_mvp.csv`, `baseline_pre_rebuild/measure_stage_a.py`, `baseline_pre_rebuild/stage_a_recall.csv`) so existing tracked files keep tracking.
   - `audit/`, `bench/`, `runs/`, `scratch/` — top-level output and scratch dirs. `scratch/` is the new local-only home for the ~26 root-level debug scripts (`nan_*.py`, `fix_verify*.py`, `magnitude_check.py`, etc.) that had been accruing.
   - `/*.pt` (root-anchored only, so `checkpoints/*.pt` isn't double-affected — `checkpoints/` is already gitignored). YOLO weight files moved from repo root into `checkpoints/`.

2. **7 operational scripts** — promoting genuinely-reusable launchers and audit helpers that had been sitting untracked in `scripts/` alongside the existing tracked launchers:
   - `lieder_eval_stage3_{launch,inner}.ps1` — paired Win32-CIM launcher pattern matching the existing `cu132_phase[34]_*_{launch,inner}.ps1` convention. Stage 3 `_best.pt` eval (max20 subset).
   - `lieder_full_inner.ps1` — Stage 3 `_best.pt` eval over the full corpus (no max20 cap).
   - `launch_mvp.ps1` — Stage 2 MVP trainer launcher.
   - `build_full_manifest.cmd` — chained `src.data.index` + `convert_tokens` builder.
   - `breakdown_audit.py`, `scan_tuplets.py` — analysis helpers over `data/grandstaff/` `.krn` files (matches the existing `scripts/audit_*.py` pattern).

The Stage 2 lieder eval pair (`lieder_eval_stage2_{launch,inner}.ps1`) was deliberately excluded — both files start with a `# THROWAWAY ... do not commit.` header and the inner script hardcodes an absolute user-specific path instead of the `$env:USERPROFILE` convention every other launcher uses. Kept on disk under `scratch/` for local reference.

The other ~8 scripts that were also untracked in `scripts/` had hardcoded PIDs from specific debugging sessions or explicit "DO NOT COMMIT" docstrings — those moved to `scratch/` instead (now gitignored).

## What's NOT in this PR

Two earlier cherry-pick candidates were dropped because they duplicated work already merged via PR #41:
- An equivalent of the `_compute_resume_position` extraction + `_resync_batch_idx_after_rebuild` helper already landed as commits `abb3f6f`, `54c9bfb`, and `e99c262`.
- An equivalent of the symmetric `cached_total=0` fallback already landed as `14000e5`.

The stale `feat/stage3-phase1-training` branch is now obsolete — recommend deletion after this PR merges.

## Test plan

- [x] No code changes outside `scripts/` and `.gitignore`
- [x] Cherry-picks applied cleanly onto current `main` (no conflicts)
- [x] All 7 scripts are net-new on `main` (verified against `origin/main` with `git cat-file -e`)
- [x] No script in this PR contains a `THROWAWAY` / `do not commit` header or hardcoded absolute user paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
