### PR TITLE
fix(pipeline): first-staff emission for global key/time signature

### DIFF
--- a/src/pipeline/assemble_score.py
+++ b/src/pipeline/assemble_score.py
@@ -289,19 +289,27 @@ def group_staves_into_systems(
 def _enforce_global_key_time(
     staves: Sequence[StaffRecognitionResult],
 ) -> List[StaffRecognitionResult]:
-    """Replace hallucinated key/time signatures with the global majority.
+    """Replace hallucinated key/time signatures with the first-staff emission.
 
-    Most pieces have a single key and time signature throughout.  The model
-    sometimes hallucinates changes (e.g. DM instead of GM, 6/8 instead of 3/4).
-    We take a majority vote across *all* staves and replace any outlier
-    key/time tokens with the consensus value.
+    The time-signature glyph is typically printed only on the first staff of
+    the first system. The decoder reads it correctly there, then has to
+    hallucinate on subsequent staves where no glyph exists. A naive majority
+    vote across all staves drowns the one informed emission in N-1
+    uninformed guesses; the model collapses to its 4/4 prior even when
+    staff 0 correctly emitted a less-common signature.
+
+    Use the first non-None emission in document order as the consensus, and
+    snap all later emissions to it.
     """
-    global_key = _majority_vote(
-        _extract_first(s.tokens, "keySignature-") for s in staves
-    )
-    global_time = _majority_vote(
-        _extract_first(s.tokens, "timeSignature-") for s in staves
-    )
+    global_key: Optional[str] = None
+    global_time: Optional[str] = None
+    for s in staves:
+        if global_key is None:
+            global_key = _extract_first(s.tokens, "keySignature-")
+        if global_time is None:
+            global_time = _extract_first(s.tokens, "timeSignature-")
+        if global_key is not None and global_time is not None:
+            break
 
     fixed: List[StaffRecognitionResult] = []
     for staff in staves:

--- a/tests/pipeline/test_enforce_global_key_time.py
+++ b/tests/pipeline/test_enforce_global_key_time.py
@@ -1,0 +1,104 @@
+"""Regression tests for _enforce_global_key_time first-emission-wins semantics.
+
+The time-signature glyph is typically printed only on the first staff of the
+first system. The decoder reads it correctly there but has to hallucinate on
+later staves with no glyph. The old majority-vote drowned the informed first
+emission in N-1 uninformed guesses; first-emission-wins keeps the signal.
+"""
+from __future__ import annotations
+
+
+def _staff(sample_id: str, key: str, time: str, *extra: str):
+    from src.pipeline.assemble_score import StaffLocation, StaffRecognitionResult
+
+    return StaffRecognitionResult(
+        sample_id=sample_id,
+        tokens=[f"keySignature-{key}", f"timeSignature-{time}", *extra],
+        location=StaffLocation(0, 0.0, 1.0, 0.0, 1.0),
+    )
+
+
+def test_first_staff_overrides_majority_for_time_signature():
+    """Staff 0 emits 9/8 (informed by visible glyph); 4 later staves emit 4/4
+    (hallucinated prior). First-emission-wins keeps 9/8 globally even though
+    4/4 is the 4:1 majority."""
+    from src.pipeline.assemble_score import _enforce_global_key_time
+
+    staves = [
+        _staff("s0", "DbM", "9/8"),
+        _staff("s1", "DbM", "4/4"),
+        _staff("s2", "DbM", "4/4"),
+        _staff("s3", "DbM", "4/4"),
+        _staff("s4", "DbM", "4/4"),
+    ]
+
+    fixed = _enforce_global_key_time(staves)
+
+    for f in fixed:
+        assert "timeSignature-9/8" in f.tokens, f"{f.sample_id} missing 9/8"
+        assert "timeSignature-4/4" not in f.tokens, f"{f.sample_id} still has 4/4"
+
+
+def test_first_staff_overrides_majority_for_key_signature():
+    from src.pipeline.assemble_score import _enforce_global_key_time
+
+    staves = [
+        _staff("s0", "EM", "4/4"),
+        _staff("s1", "CM", "4/4"),
+        _staff("s2", "CM", "4/4"),
+        _staff("s3", "CM", "4/4"),
+    ]
+
+    fixed = _enforce_global_key_time(staves)
+
+    for f in fixed:
+        assert "keySignature-EM" in f.tokens
+        assert "keySignature-CM" not in f.tokens
+
+
+def test_falls_through_when_first_staff_emits_no_signature():
+    """If staff 0 didn't emit a time/key token, use the first staff that did."""
+    from src.pipeline.assemble_score import (
+        StaffLocation,
+        StaffRecognitionResult,
+        _enforce_global_key_time,
+    )
+
+    staves = [
+        StaffRecognitionResult(
+            sample_id="s0",
+            tokens=["clef-G2"],  # no key, no time
+            location=StaffLocation(0, 0.0, 1.0, 0.0, 1.0),
+        ),
+        _staff("s1", "EbM", "3/4"),
+        _staff("s2", "EbM", "4/4"),
+    ]
+
+    fixed = _enforce_global_key_time(staves)
+
+    # s2's 4/4 should be rewritten to s1's 3/4
+    assert "timeSignature-3/4" in fixed[2].tokens
+    assert "timeSignature-4/4" not in fixed[2].tokens
+
+
+def test_no_signatures_anywhere_is_a_noop():
+    from src.pipeline.assemble_score import (
+        StaffLocation,
+        StaffRecognitionResult,
+        _enforce_global_key_time,
+    )
+
+    staves = [
+        StaffRecognitionResult(
+            sample_id=f"s{i}",
+            tokens=["clef-G2", "<measure_start>", "rest", "_whole", "<measure_end>"],
+            location=StaffLocation(0, 0.0, 1.0, 0.0, 1.0),
+        )
+        for i in range(3)
+    ]
+
+    fixed = _enforce_global_key_time(staves)
+
+    # Tokens unchanged (no key/time emissions to rewrite)
+    for original, after in zip(staves, fixed):
+        assert original.tokens == after.tokens


### PR DESCRIPTION
## Summary

- Replace majority-vote-across-all-staves logic in `_enforce_global_key_time` with first-non-None-emission in document order
- The time-signature glyph is typically printed only on staff 0 of system 0; the decoder reads it correctly there but has to hallucinate on N-1 later staves. Majority vote drowns one informed reading in many uninformed guesses
- Add regression tests covering first-emission semantics, fallthrough, and no-op cases

## Diagnosis

Per-staff probe of the Stage 3 v2 RADIO checkpoint on the 4-piece HF demo eval (added `probe_keytime.py`-style monkey-patch; not in this PR):

| Piece | Reference | Staff 0 | Old majority | New first-emission |
|---|---|---|---|---|
| Clair de Lune | 9/8 | 6/8 | 4/4 (54 of 58) | 6/8 |
| Fugue BWV 847 | 4/4 | 4/4 | 4/4 (9 of 15) | 4/4 (no-op) |
| Gnossienne | (none) | 4/4 | 4/4 (15 of 15) | 4/4 (no-op) |
| Prelude Op.31 | 3/4 | **3/4** | 4/4 (21 of 23) | **3/4** ✓ |

The decoder reads non-4/4 signatures on the first staff where the glyph is visible, then collapses to its 4/4 prior on later staves. The previous vote always picked the prior; this PR picks the informed reading.

## Re-eval (Stage 3 v2 best, 300 dpi, greedy)

| piece | old onset_f1 | new onset_f1 | Δ |
|---|---:|---:|---:|
| clair-de-lune-debussy | 0.0329 | 0.0340 | +0.001 |
| fugue-no-2-bwv-847 | 0.0515 | 0.0631 | +0.012 |
| gnossienne-no-1 | 0.1066 | 0.1032 | −0.003 |
| prelude-op31-no1 | 0.0246 | 0.0352 | **+0.011 (+43% rel)** |
| **mean** | **0.0539** | **0.0589** | **+0.005** |

Prelude's `time_sig_match` flag flips False→True. Other pieces are within ±0.003-0.012 run-to-run inference-determinism noise; only Prelude shows a signal from the patch.

## Caveats

- Does NOT close the gap to the 0.241 decision gate. The model still under-generates notes by 25-50% per piece and gets key signatures wrong on 2 of 4 pieces. Those are separate failure modes that aren't addressed here
- Pieces with mid-piece time-signature changes still get clobbered globally (same limitation as the old logic — both approaches enforce a single signature across the piece)

## Test plan

- [x] Local pytest collects 4 new tests (CUDA-gated → skipped on local; runnable on seder)
- [x] Full 4-piece demo eval re-run on Stage 3 v2 checkpoint shows expected per-piece deltas above
- [ ] Reviewer: confirm seder pytest runs `tests/pipeline/test_enforce_global_key_time.py` with all 4 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)