### PR TITLE
feat(inference): add run_image + extend predict_pdf to accept page images

### DIFF
--- a/scripts/predict_pdf.py
+++ b/scripts/predict_pdf.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
-"""Predict MusicXML for a single PDF using a trained Stage A + Stage B checkpoint.
+"""Predict MusicXML for a single PDF or page image using a trained checkpoint.
 
 Runs the full SystemInferencePipeline (YOLO system detection -> Stage B
-seq2seq decode per system -> assembly -> Stage D MusicXML export) on one PDF
-and writes the resulting MusicXML to the path you choose. Defaults to the
-latest Stage 3 v3 checkpoint and the standard YOLO weights so the common case
-is a one-line invocation.
+seq2seq decode per system -> assembly -> Stage D MusicXML export) on one
+input and writes the resulting MusicXML to the path you choose. Defaults to
+the latest Stage 3 v3 checkpoint and the standard YOLO weights so the common
+case is a one-line invocation.
+
+Input format is dispatched on file extension:
+  * ``.pdf``                       -> SystemInferencePipeline.run_pdf
+  * any image PIL can open
+    (``.jpg``, ``.png``, ``.tif``, etc.) -> SystemInferencePipeline.run_image
 
 Usage (on seder):
     venv-cu132\\Scripts\\python -m scripts.predict_pdf \\
         data\\scratch\\score.pdf \\
         data\\scratch\\score.musicxml
+
+    venv-cu132\\Scripts\\python -m scripts.predict_pdf \\
+        Downloads\\Scanned_20251208-0833.jpg \\
+        Downloads\\Scanned_20251208-0833.musicxml
 
 With overrides:
     venv-cu132\\Scripts\\python -m scripts.predict_pdf \\
@@ -41,8 +50,10 @@ _DEFAULT_YOLO_WEIGHTS = "runs/detect/runs/yolo26m_systems/weights/best.pt"
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("pdf", type=Path, help="Input PDF to transcribe.")
-    p.add_argument("out", type=Path, help="Output MusicXML path (parent dir auto-created).")
+    p.add_argument("input", type=Path,
+                   help="Input PDF or page image (.jpg/.png/.tif/.bmp/.webp/etc.) to transcribe.")
+    p.add_argument("out", type=Path,
+                   help="Output MusicXML path (parent dir auto-created).")
     p.add_argument(
         "--stage-b-ckpt", type=Path, default=Path(_DEFAULT_STAGE_B_CKPT),
         help=f"Path to Stage B checkpoint (.pt). Default: {_DEFAULT_STAGE_B_CKPT}",
@@ -67,8 +78,8 @@ def main() -> int:
     )
     args = p.parse_args()
 
-    if not args.pdf.is_file():
-        p.error(f"PDF not found: {args.pdf}")
+    if not args.input.is_file():
+        p.error(f"Input not found: {args.input}")
     if not args.stage_b_ckpt.is_file():
         p.error(
             f"Stage B checkpoint not found: {args.stage_b_ckpt}. "
@@ -81,7 +92,10 @@ def main() -> int:
         )
     args.out.parent.mkdir(parents=True, exist_ok=True)
 
-    print(f"PDF:             {args.pdf}")
+    is_pdf = args.input.suffix.lower() == ".pdf"
+    input_kind = "PDF" if is_pdf else "image"
+
+    print(f"Input ({input_kind}): {args.input}")
     print(f"Output MusicXML: {args.out}")
     print(f"Stage B ckpt:    {args.stage_b_ckpt}")
     print(f"YOLO weights:    {args.yolo_weights}")
@@ -108,7 +122,10 @@ def main() -> int:
     diags = StageDExportDiagnostics()
     print("Running inference ...")
     t1 = time.time()
-    score = pipeline.run_pdf(args.pdf, diagnostics=diags)
+    if is_pdf:
+        score = pipeline.run_pdf(args.input, diagnostics=diags)
+    else:
+        score = pipeline.run_image(args.input, diagnostics=diags)
     n_staves = sum(len(system.staves) for system in score.systems)
     print(f"  decoded {len(score.systems)} systems, {n_staves} staves total "
           f"in {time.time() - t1:.1f}s")

--- a/src/inference/system_pipeline.py
+++ b/src/inference/system_pipeline.py
@@ -103,6 +103,42 @@ class SystemInferencePipeline:
             all_token_lists, all_locations, diagnostics=diagnostics,
         )
 
+    def run_image(
+        self,
+        image,
+        *,
+        diagnostics=None,
+    ) -> AssembledScore:
+        """Run Stage A + Stage B on a single page image, assemble.
+
+        Mirrors ``run_pdf`` but takes one already-rendered page image instead of
+        a PDF. Useful for direct image input (scans, single-page JPG/PNG/etc.)
+        without converting to PDF first. ``image`` may be a path
+        (``str``/``Path``) or a PIL ``Image.Image``; the file extension is not
+        checked, so any format PIL can decode works.
+        """
+        if isinstance(image, Image.Image):
+            img = image.convert("RGB") if image.mode != "RGB" else image
+        else:
+            img = Image.open(str(image)).convert("RGB")
+        all_token_lists = []
+        all_locations = []
+        systems = self._stage_a.detect_systems(img)
+        for sys in systems:
+            x1, y1, x2, y2 = sys["bbox_extended"]
+            crop = img.crop((int(x1), int(y1), int(x2), int(y2)))
+            tokens = self._decode_one_crop(crop)
+            all_token_lists.append(tokens)
+            all_locations.append({
+                "system_index": sys["system_index"],
+                "bbox": sys["bbox_extended"],
+                "page_index": 0,
+                "conf": sys["conf"],
+            })
+        return assemble_score_from_system_predictions(
+            all_token_lists, all_locations, diagnostics=diagnostics,
+        )
+
     def run_page(
         self,
         page_image: Image.Image,


### PR DESCRIPTION
## Summary

Adds `SystemInferencePipeline.run_image`, mirroring `run_pdf` but on a single already-rendered page image (PIL `Image.Image` or file path). Lets the pipeline consume scanned scores, single-page JPG/PNG/etc. without round-tripping through a PDF.

`scripts/predict_pdf.py` now dispatches on input file extension:
- `.pdf` → `pipeline.run_pdf` (existing path, unchanged)
- anything else PIL can decode → `pipeline.run_image` (new path)

Positional CLI arg renamed `pdf` → `input` to match. Help text + docstring updated.

## Verification

Tested on seder against `C:\Users\Jonathan Wesely\Downloads\Scanned_20251208-0833.jpg`:
```
Input (image):   C:\Users\Jonathan Wesely\Downloads\Scanned_20251208-0833.jpg
...
Loading pipeline ...  ready in 7.4s
Running inference ...
  decoded 4 systems, 7 staves total in 5.2s
Exporting MusicXML ...
  wrote 19 KB in 0.2s
Done in 12.7s total.
```

PDF path is unchanged — the new branch only wraps `run_pdf` in an `if is_pdf:` and otherwise routes to the new `run_image`. No re-test of PDF input needed (PR #51 verified it 7 minutes ago against gnossienne-no-1).

## Test plan

- [ ] Reviewer: run on any non-PDF image; confirm output `.musicxml` opens in a viewer.
- [ ] Reviewer: spot-check the new `run_image` method in `src/inference/system_pipeline.py` matches `run_pdf`'s assembly contract (same `all_token_lists` + `all_locations` shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)