### PR TITLE
feat(inference): --dump-tokens flag for per-system raw decoder output

### DIFF
--- a/scripts/predict_pdf.py
+++ b/scripts/predict_pdf.py
@@ -37,6 +37,7 @@ import json
 import sys
 import time
 from pathlib import Path
+from typing import Optional
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
@@ -75,6 +76,15 @@ def main() -> int:
     p.add_argument(
         "--diagnostics-out", type=Path, default=None,
         help="Optional path to write Stage D export diagnostics JSON sidecar.",
+    )
+    p.add_argument(
+        "--dump-tokens", type=Path, default=None,
+        help=(
+            "Optional path to write a JSONL sidecar containing one record per "
+            "detected system: {system_index, page_index, bbox, conf, tokens, "
+            "n_tokens}. Useful for debugging clef/staff-ordering failures by "
+            "inspecting the raw decoder output prior to Stage D export."
+        ),
     )
     args = p.parse_args()
 
@@ -120,12 +130,13 @@ def main() -> int:
     print(f"  ready in {time.time() - t0:.1f}s")
 
     diags = StageDExportDiagnostics()
+    token_log: Optional[list] = [] if args.dump_tokens is not None else None
     print("Running inference ...")
     t1 = time.time()
     if is_pdf:
-        score = pipeline.run_pdf(args.input, diagnostics=diags)
+        score = pipeline.run_pdf(args.input, diagnostics=diags, token_log=token_log)
     else:
-        score = pipeline.run_image(args.input, diagnostics=diags)
+        score = pipeline.run_image(args.input, diagnostics=diags, token_log=token_log)
     n_staves = sum(len(system.staves) for system in score.systems)
     print(f"  decoded {len(score.systems)} systems, {n_staves} staves total "
           f"in {time.time() - t1:.1f}s")
@@ -142,6 +153,13 @@ def main() -> int:
         diag_payload = {k: v for k, v in vars(diags).items() if not k.startswith("_")}
         args.diagnostics_out.write_text(json.dumps(diag_payload, indent=2, default=str), encoding="utf-8")
         print(f"  diagnostics JSON: {args.diagnostics_out}")
+
+    if args.dump_tokens is not None:
+        args.dump_tokens.parent.mkdir(parents=True, exist_ok=True)
+        with args.dump_tokens.open("w", encoding="utf-8") as f:
+            for entry in token_log or []:
+                f.write(json.dumps(entry) + "\n")
+        print(f"  raw token JSONL: {args.dump_tokens}  ({len(token_log or [])} systems)")
 
     total = time.time() - t0
     print()

--- a/src/inference/system_pipeline.py
+++ b/src/inference/system_pipeline.py
@@ -70,6 +70,7 @@ class SystemInferencePipeline:
         pdf_path,
         *,
         diagnostics=None,
+        token_log: Optional[list] = None,
     ) -> AssembledScore:
         """Render PDF pages, run Stage A + Stage B per page, assemble.
 
@@ -78,6 +79,12 @@ class SystemInferencePipeline:
         `skipped_systems` for each system whose decoder output failed
         token validation (decoder truncation). It is also forwarded to
         `export_musicxml` for Stage-D skip recording.
+
+        When `token_log` is supplied (a list), one dict per system is
+        appended to it before assembly with keys ``system_index``,
+        ``page_index``, ``bbox``, ``conf``, ``tokens``, ``n_tokens``.
+        Intended for debugging clef / staff-ordering failures by
+        inspecting the raw decoder output prior to Stage D export.
         """
         all_token_lists = []
         all_locations = []
@@ -99,6 +106,15 @@ class SystemInferencePipeline:
                         "page_index": page_index,
                         "conf": sys["conf"],
                     })
+                    if token_log is not None:
+                        token_log.append({
+                            "system_index": int(sys["system_index"]),
+                            "page_index": int(page_index),
+                            "bbox": [int(x1), int(y1), int(x2), int(y2)],
+                            "conf": float(sys["conf"]),
+                            "tokens": list(tokens),
+                            "n_tokens": len(tokens),
+                        })
         return assemble_score_from_system_predictions(
             all_token_lists, all_locations, diagnostics=diagnostics,
         )
@@ -108,6 +124,7 @@ class SystemInferencePipeline:
         image,
         *,
         diagnostics=None,
+        token_log: Optional[list] = None,
     ) -> AssembledScore:
         """Run Stage A + Stage B on a single page image, assemble.
 
@@ -116,6 +133,9 @@ class SystemInferencePipeline:
         without converting to PDF first. ``image`` may be a path
         (``str``/``Path``) or a PIL ``Image.Image``; the file extension is not
         checked, so any format PIL can decode works.
+
+        ``token_log`` (optional list) is appended with one dict per system in
+        the same shape as ``run_pdf`` — see that method for the schema.
         """
         if isinstance(image, Image.Image):
             img = image.convert("RGB") if image.mode != "RGB" else image
@@ -135,6 +155,15 @@ class SystemInferencePipeline:
                 "page_index": 0,
                 "conf": sys["conf"],
             })
+            if token_log is not None:
+                token_log.append({
+                    "system_index": int(sys["system_index"]),
+                    "page_index": 0,
+                    "bbox": [int(x1), int(y1), int(x2), int(y2)],
+                    "conf": float(sys["conf"]),
+                    "tokens": list(tokens),
+                    "n_tokens": len(tokens),
+                })
         return assemble_score_from_system_predictions(
             all_token_lists, all_locations, diagnostics=diagnostics,
         )


### PR DESCRIPTION
## Summary

Adds optional `token_log` capture to `SystemInferencePipeline.run_pdf` and `run_image`. When supplied a list, the pipeline appends one dict per system before assembly:

```json
{"system_index": 0, "page_index": 0, "bbox": [x1,y1,x2,y2], "conf": 0.55,
 "tokens": ["<bos>", "<staff_start>", "<staff_idx_0>", "clef-G2", ...],
 "n_tokens": 89}
```

Surfaced via `--dump-tokens <path>` on `scripts/predict_pdf.py` which writes the list as a JSONL sidecar. Lets you inspect raw Stage B output before Stage D's assembly collapses it into the MusicXML — critical when the MXL gives a misleading picture (assembly stripes staves across parts based on staff_idx markers, so a mismatch in per-system staff counts can hide the real failure mode).

## Real diagnostic value

First use surfaced a richer failure than the MXL suggested. On a scanned `O Little Town of Bethlehem` (4 visible systems):

```
sys 0  y=584-1311   conf=0.557  2 staves  clefs=[G2, F4]      ✓ correct
sys 1  y=2047-2767  conf=0.343  3 staves  clefs=[G2, G2, F4]  ← merged 2 systems
sys 2  y=2785-3554  conf=0.966  2 staves  clefs=[G2, G2]      ✗ bass→treble
```

Two distinct failure modes on one input:
1. Stage A YOLO missed visual system 2 entirely (gap between sys 0 and sys 1 detections) AND merged systems 2+3 into one 3-staff detection at low confidence (0.343).
2. Stage B emitted treble clef on a high-confidence (0.966) detection's bass staff — direct decoder mis-classification.

The MXL's "alternating bass clef" pattern was actually Stage D's assembly trying to reconcile mismatched staff counts (2 + 3 + 2) across systems — not a single clef-classifier oscillation.

## Test plan

- [ ] Reviewer: run with `--dump-tokens out.jsonl` on any PDF/image; confirm one JSONL row per detected system.
- [ ] Reviewer: confirm normal runs (no `--dump-tokens`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)