### PR TITLE
feat(inference): --yolo-conf flag on predict_pdf

### DIFF
--- a/scripts/predict_pdf.py
+++ b/scripts/predict_pdf.py
@@ -71,6 +71,12 @@ def main() -> int:
                    help="Max decode steps per system crop. Default 2048.")
     p.add_argument("--page-dpi", type=int, default=300,
                    help="PDF render DPI for Stage A. Default 300 (matches training).")
+    p.add_argument("--yolo-conf", type=float, default=0.25,
+                   help=(
+                       "Stage A YOLO confidence threshold. Default 0.25 (YOLO's default). "
+                       "Lower values (0.05-0.15) can recover systems on noisy scans at "
+                       "the cost of more false-positive detections."
+                   ))
     p.add_argument("--fp16", action="store_true",
                    help="Use fp16 for Stage B inference (small accuracy risk, faster).")
     p.add_argument(
@@ -111,6 +117,7 @@ def main() -> int:
     print(f"YOLO weights:    {args.yolo_weights}")
     print(f"Device:          {args.device}  fp16={args.fp16}")
     print(f"Beam:            {args.beam_width}  max_decode_steps={args.max_decode_steps}")
+    print(f"YOLO conf:       {args.yolo_conf}")
     print()
 
     from src.inference.system_pipeline import SystemInferencePipeline
@@ -126,6 +133,7 @@ def main() -> int:
         max_decode_steps=args.max_decode_steps,
         page_dpi=args.page_dpi,
         use_fp16=args.fp16,
+        yolo_conf=args.yolo_conf,
     )
     print(f"  ready in {time.time() - t0:.1f}s")
 

--- a/src/inference/system_pipeline.py
+++ b/src/inference/system_pipeline.py
@@ -52,9 +52,10 @@ class SystemInferencePipeline:
         length_penalty_alpha: float = 0.4,
         use_fp16: bool = False,
         quantize: bool = False,
+        yolo_conf: float = 0.25,
     ):
         self._device = torch.device(device)
-        self._stage_a = YoloStageASystems(yolo_weights)
+        self._stage_a = YoloStageASystems(yolo_weights, conf=yolo_conf)
         self._bundle: StageBInferenceBundle = load_stage_b_for_inference(
             stage_b_ckpt, self._device, use_fp16=use_fp16, quantize=quantize,
         )


### PR DESCRIPTION
## Summary

Plumbs the Stage A YOLO confidence threshold through `SystemInferencePipeline` (new kwarg `yolo_conf`, default 0.25 matching `YoloStageASystems`' own default) and exposes it on `scripts/predict_pdf.py` via `--yolo-conf`.

Lets you trade off Stage A recall vs precision per-input without editing code, which matters on noisy real-world scans where the default 0.25 drops genuine systems.

## Empirical motivation

On the \"O Little Town of Bethlehem\" scan that prompted this:

| `--yolo-conf` | n detections | Notes |
|---|---|---|
| 0.25 (default) | 3 of 4 systems | One visual system entirely missed; another at conf 0.343 mis-decoded as a 3-staff system |
| 0.10 | same 3 | Threshold isn't between 0.10 and 0.25 |
| 0.01 | 5 detections | All 4 visual systems recovered (missing one came in at conf 0.046), plus 1 junk detection on the title area at conf 0.013 |

A more selective threshold (~0.05) likely keeps the recovery without the junk; that calibration is now under the user's control.

## Test plan

- [ ] Reviewer: run with `--yolo-conf 0.10` on any input; confirm n_detections >= default-conf n_detections.
- [ ] Reviewer: confirm omitting `--yolo-conf` is unchanged (defaults to 0.25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)